### PR TITLE
fix(frontend): resolve 40 verified GUI bugs from audit (#61)

### DIFF
--- a/backend/routers/upgrades.py
+++ b/backend/routers/upgrades.py
@@ -830,13 +830,19 @@ async def ws_upgrade_all(websocket: WebSocket):
         allow_phased = params.get("allow_phased", False)
         conffile_action = params.get("conffile_action", "confdef_confold")
         reboot_if_required = params.get("reboot_if_required", False)
+        # Optional explicit target set (e.g. the dashboard's active filter). When omitted
+        # we fall back to every enabled server, preserving the original behaviour.
+        explicit_ids = params.get("server_ids") or None
 
         cfg_res = await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))
         cfg = cfg_res.scalar_one_or_none()
         concurrency = cfg.upgrade_concurrency if cfg else 5
         run_apt_update = cfg.run_apt_update_before_upgrade if cfg else False
 
-        srv_res = await db.execute(select(Server).where(Server.is_enabled == True))
+        srv_query = select(Server).where(Server.is_enabled == True)
+        if explicit_ids:
+            srv_query = srv_query.where(Server.id.in_(explicit_ids))
+        srv_res = await db.execute(srv_query)
         servers = srv_res.scalars().all()
 
         to_upgrade = []

--- a/backend/routers/upgrades.py
+++ b/backend/routers/upgrades.py
@@ -1215,11 +1215,22 @@ async def ws_autoremove_all(websocket: WebSocket):
             await websocket.close(code=1008)
             return
 
+        try:
+            raw = await asyncio.wait_for(websocket.receive_text(), timeout=10)
+            params = json.loads(raw)
+        except Exception:
+            params = {}
+        # Optional explicit target set (the dashboard's active filter); omitted = all enabled.
+        explicit_ids = params.get("server_ids") or None
+
         cfg_res = await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))
         cfg = cfg_res.scalar_one_or_none()
         concurrency = cfg.upgrade_concurrency if cfg else 5
 
-        srv_res = await db.execute(select(Server).where(Server.is_enabled == True))
+        srv_query = select(Server).where(Server.is_enabled == True)
+        if explicit_ids:
+            srv_query = srv_query.where(Server.id.in_(explicit_ids))
+        srv_res = await db.execute(srv_query)
         servers = srv_res.scalars().all()
 
         to_clean = []

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apt Dashboard</title>
+    <script>
+      // Apply the persisted theme before React mounts, so the login / "initializing"
+      // screens (rendered outside Layout, which is the only useTheme consumer) are
+      // themed and there's no dark→light flash on load.
+      try { if (localStorage.getItem('apt:theme') === 'light') document.documentElement.classList.add('light') } catch (e) {}
+    </script>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import { useAuthStore } from '@/hooks/useAuth'
 import RequireAuth from '@/components/RequireAuth'
 import Layout from '@/components/Layout'
@@ -13,6 +13,16 @@ import Compare from '@/pages/Compare'
 import Search from '@/pages/Search'
 import Reports from '@/pages/Reports'
 import Security from '@/pages/Security'
+
+// Keyed by :id so navigating between servers (e.g. via the command palette) fully
+// remounts ServerDetail and all its tab children. Without this, react-router reuses
+// the same element across param changes, leaving per-tab state (notably the Apt Repos
+// editor) pointing at the previous server — which could save server A's repo files
+// onto server B.
+function ServerDetailRoute() {
+  const { id } = useParams()
+  return <ServerDetail key={id} />
+}
 
 export default function App() {
   const { init } = useAuthStore()
@@ -40,7 +50,7 @@ export default function App() {
           element={
             <RequireAuth>
               <Layout>
-                <ServerDetail />
+                <ServerDetailRoute />
               </Layout>
             </RequireAuth>
           }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -580,9 +580,11 @@ export function createAutoremoveWebSocket(
 export function createAutoremoveAllWebSocket(
   onMessage: (msg: Record<string, unknown>) => void,
   onClose?: (ev?: CloseEvent) => void,
+  params?: { server_ids?: number[] },
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/autoremove-all`
   const ws = new WebSocket(url)
+  ws.onopen = () => { ws.send(JSON.stringify(params ?? {})) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
   ws.onclose = wsClose(onClose)
   return ws

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,11 +38,19 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   })
 
   if (res.status === 401) {
-    // Redirect to login unless already there
+    // Preserve the backend's detail (e.g. "2FA code required", "Invalid credentials",
+    // "Invalid 2FA code") so callers like Login can react. Without this, every 401 was
+    // flattened to "Session expired", which made 2FA login impossible.
+    let detail = 'Session expired'
+    try {
+      const body = await res.json()
+      if (body?.detail) detail = body.detail
+    } catch {}
+    // Redirect to login unless already there (the login page surfaces the detail instead).
     if (!window.location.pathname.startsWith('/login')) {
       window.location.href = '/login?expired=1'
     }
-    throw new ApiError(401, 'Session expired')
+    throw new ApiError(401, detail)
   }
 
   if (!res.ok) {
@@ -490,11 +498,23 @@ export const aptcache = {
 // WebSocket helpers
 // ---------------------------------------------------------------------------
 
+// Shared onclose wrapper: forwards the CloseEvent to the caller (so consumers can
+// distinguish a clean completion from a failure via ev.wasClean / ev.code) and, on
+// an auth-failure close (server sends 1008), redirects to login like an HTTP 401 does.
+function wsClose(onClose?: (ev?: CloseEvent) => void) {
+  return (ev: CloseEvent) => {
+    if (ev.code === 1008 && !window.location.pathname.startsWith('/login')) {
+      window.location.href = '/login?expired=1'
+    }
+    onClose?.(ev)
+  }
+}
+
 export function createUpgradeWebSocket(
   serverId: number | 'all',
   params: { action: string; allow_phased: boolean; reboot_if_required?: boolean },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = serverId === 'all'
     ? `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/upgrade-all`
@@ -512,7 +532,7 @@ export function createUpgradeWebSocket(
     } catch {}
   }
 
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
 
   return ws
 }
@@ -521,25 +541,25 @@ export function createSelectiveUpgradeWebSocket(
   serverId: number,
   params: { packages: string[]; allow_phased: boolean },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/upgrade-selective/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params)) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
 export function createAptUpdateWebSocket(
   serverId: number,
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/apt-update/${serverId}`
   const ws = new WebSocket(url)
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -547,37 +567,37 @@ export function createAutoremoveWebSocket(
   serverId: number,
   params: { packages: string[] | null },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/autoremove/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params)) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
 export function createAutoremoveAllWebSocket(
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/autoremove-all`
   const ws = new WebSocket(url)
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
 export function createRebootAllWebSocket(
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
   params?: { server_ids?: number[] },
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/reboot-all`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params ?? {})) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -585,13 +605,13 @@ export function createInstallWebSocket(
   serverId: number,
   packages: string[],
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/install/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify({ packages })) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -599,37 +619,37 @@ export function createDryRunWebSocket(
   serverId: number,
   params: { action: string; allow_phased: boolean },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/dry-run/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params)) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
 export function createEepromUpdateWebSocket(
   serverId: number,
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/eeprom-update/${serverId}`
   const ws = new WebSocket(url)
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
 export function createPveUpgradeWebSocket(
   serverId: number,
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/pveupgrade/${serverId}`
   const ws = new WebSocket(url)
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -637,13 +657,13 @@ export function createAptProxyWebSocket(
   serverId: number,
   params: { enable: boolean; mode?: 'manual' | 'auto'; proxy_url?: string },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/apt-proxy/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params)) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -651,13 +671,13 @@ export function createAutoSecurityUpdatesWebSocket(
   serverId: number,
   params: { enable: boolean },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/auto-security-updates/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params)) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -665,13 +685,13 @@ export function createTemplateApplyWebSocket(
   templateId: number,
   serverIds: number[],
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/template-apply/${templateId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify({ server_ids: serverIds })) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
@@ -679,24 +699,24 @@ export function createInstallDebWebSocket(
   serverId: number,
   params: { source: 'url'; url: string } | { source: 'remote'; path: string },
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/install-deb/${serverId}`
   const ws = new WebSocket(url)
   ws.onopen = () => { ws.send(JSON.stringify(params)) }
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }
 
 export function createAptReposTestWebSocket(
   serverId: number,
   onMessage: (msg: Record<string, unknown>) => void,
-  onClose?: () => void,
+  onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {
   const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/apt-repos-test/${serverId}`
   const ws = new WebSocket(url)
   ws.onmessage = (event) => { try { onMessage(JSON.parse(event.data)) } catch {} }
-  ws.onclose = () => onClose?.()
+  ws.onclose = wsClose(onClose)
   return ws
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -512,7 +512,7 @@ function wsClose(onClose?: (ev?: CloseEvent) => void) {
 
 export function createUpgradeWebSocket(
   serverId: number | 'all',
-  params: { action: string; allow_phased: boolean; reboot_if_required?: boolean },
+  params: { action: string; allow_phased: boolean; reboot_if_required?: boolean; server_ids?: number[] },
   onMessage: (msg: Record<string, unknown>) => void,
   onClose?: (ev?: CloseEvent) => void,
 ): WebSocket {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -230,11 +230,11 @@ export const servers = {
     post<{ package: string; hold: boolean; results: Record<string, { success: boolean; stdout: string; stderr: string }> }>(
       '/api/servers/bulk-hold', { server_ids, package: pkg, hold }
     ),
-  uploadDeb: (id: number, file: File) => {
+  uploadDeb: (id: number, file: File, signal?: AbortSignal) => {
     const form = new FormData()
     form.append('file', file)
     return fetch(`/api/servers/${id}/upload-deb`, {
-      method: 'POST', credentials: 'include', body: form,
+      method: 'POST', credentials: 'include', body: form, signal,
     }).then(async r => {
       if (!r.ok) {
         const body = await r.json().catch(() => ({}))

--- a/frontend/src/components/AutoremoveAllModal.tsx
+++ b/frontend/src/components/AutoremoveAllModal.tsx
@@ -18,6 +18,9 @@ interface ServerProgress {
 
 export default function AutoremoveAllModal({ servers, onClose }: Props) {
   const [started, setStarted] = useState(false)
+  // Snapshot of targets at start(); running view renders from this so the dashboard
+  // poll mutating the live `servers` prop can't make rows vanish mid-operation.
+  const [runServers, setRunServers] = useState<Server[]>([])
   const [progress, setProgress] = useState<Record<number, ServerProgress>>({})
   const [done, setDone] = useState(false)
   const [filterServer, setFilterServer] = useState<number | null>(null)
@@ -32,16 +35,18 @@ export default function AutoremoveAllModal({ servers, onClose }: Props) {
   }, [])
 
   function start() {
+    const snapshot = servers
     setStarted(true)
-    pendingRef.current = servers.length
+    setRunServers(snapshot)
+    pendingRef.current = snapshot.length
     const initial: Record<number, ServerProgress> = {}
-    servers.forEach(s => { initial[s.id] = { status: 'pending', lines: [] } })
+    snapshot.forEach(s => { initial[s.id] = { status: 'pending', lines: [] } })
     setProgress(initial)
 
     addJob({
       id: 'autoremove-all',
       type: 'upgrade-all',
-      label: `Autoremove All (${servers.length} servers)`,
+      label: `Autoremove All (${snapshot.length} servers)`,
       status: 'running',
       link: '/',
       startedAt: Date.now(),
@@ -78,7 +83,25 @@ export default function AutoremoveAllModal({ servers, onClose }: Props) {
           updateJob('autoremove-all', { status: 'error', completedAt: Date.now() })
         }
       }
-    }, () => setDone(true))
+    }, (ev) => {
+      setDone(true)
+      if (pendingRef.current > 0) {
+        pendingRef.current = 0
+        updateJob('autoremove-all', { status: 'error', completedAt: Date.now() })
+        const note = ev && !ev.wasClean
+          ? '✗ Connection closed before this server finished.'
+          : '✗ Stream ended without a completion message.'
+        setProgress(p => {
+          const next: Record<number, ServerProgress> = {}
+          for (const [k, v] of Object.entries(p)) {
+            next[+k] = (v.status === 'pending' || v.status === 'running')
+              ? { ...v, status: 'error', lines: [...v.lines, note] }
+              : v
+          }
+          return next
+        })
+      }
+    }, { server_ids: servers.map(s => s.id) })
 
     wsRef.current = ws
   }
@@ -136,7 +159,7 @@ export default function AutoremoveAllModal({ servers, onClose }: Props) {
               >
                 All
               </button>
-              {servers.map(s => {
+              {runServers.map(s => {
                 const p = progress[s.id]
                 const active = filterServer === s.id
                 const borderColor =
@@ -163,7 +186,7 @@ export default function AutoremoveAllModal({ servers, onClose }: Props) {
               className="flex-1 overflow-y-auto bg-bg border border-border rounded p-2 font-mono text-xs text-text-primary min-h-0"
               style={{ maxHeight: '40vh' }}
             >
-              {servers.flatMap(s => {
+              {runServers.flatMap(s => {
                 if (filterServer !== null && filterServer !== s.id) return []
                 return (progress[s.id]?.lines || []).map((line, i) => (
                   <div key={`${s.id}-${i}`}>

--- a/frontend/src/components/AutoremoveAllModal.tsx
+++ b/frontend/src/components/AutoremoveAllModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import type { Server } from '@/types'
 import { createAutoremoveAllWebSocket } from '@/api/client'
 import { useJobStore } from '@/hooks/useJobStore'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
 import Convert from 'ansi-to-html'
 
 const ansiConvert = new Convert({ escapeXML: true })
@@ -33,6 +34,9 @@ export default function AutoremoveAllModal({ servers, onClose }: Props) {
   useEffect(() => {
     return () => { wsRef.current?.close() }
   }, [])
+
+  // Escape closes the modal before start or once done (not mid-run).
+  useEscapeKey(handleClose, !started || done)
 
   function start() {
     const snapshot = servers

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -169,11 +169,12 @@ export default function CommandPalette() {
   const [filter, setFilter] = useState<FilterChip>('all')
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
+  const prevFocusRef = useRef<HTMLElement | null>(null)
 
   const navigate = useNavigate()
   const { logout } = useAuthStore()
   const { jobs } = useJobStore()
-  const { servers, loaded, load, setServers } = useServersStore()
+  const { servers, load } = useServersStore()
 
   // ----- open/close --------------------------------------------------------
 
@@ -212,19 +213,23 @@ export default function CommandPalette() {
     }
   }, [openPalette])
 
-  // Hydrate the server list when the palette is first opened
+  // Refresh the server list every time the palette opens, so servers added or
+  // removed in Settings (which mutate component state, not this store) show up,
+  // and deleted ones disappear, without waiting for the 30s dashboard poll.
   useEffect(() => {
-    if (open && !loaded) {
-      load()
-    }
-  }, [open, loaded, load])
+    if (open) load()
+  }, [open, load])
 
-  // Focus input on open
+  // Focus input on open; restore focus to the previously-focused element on close.
   useEffect(() => {
     if (open) {
+      prevFocusRef.current = document.activeElement as HTMLElement | null
       // Defer to next paint so the input is mounted
       const t = setTimeout(() => inputRef.current?.focus(), 0)
-      return () => clearTimeout(t)
+      return () => {
+        clearTimeout(t)
+        prevFocusRef.current?.focus?.()
+      }
     }
   }, [open])
 
@@ -398,7 +403,9 @@ export default function CommandPalette() {
     }
 
     return out
-  }, [servers, jobs, navigate, logout])
+    // `open` is a dep so the recent-servers list (read from localStorage) is
+    // re-evaluated each time the palette opens.
+  }, [servers, jobs, navigate, logout, open])
 
   // ----- filter + score ----------------------------------------------------
 
@@ -418,12 +425,12 @@ export default function CommandPalette() {
     for (const it of filtered) {
       const m = fuzzyMatch(q, it.haystack)
       if (!m) continue
-      // Keep label-position highlight, mapping haystack indices that fall in
-      // the label slice. Since haystack starts with `${label} ...` this is
-      // a clean prefix slice of positions <= label.length.
-      const labelLen = it.label.length
-      const labelPositions = m.positions.filter((p) => p < labelLen)
-      scored.push({ item: it, positions: labelPositions, score: m.score })
+      // Score against the haystack (so hint matches still rank), but compute the
+      // highlight positions against the label itself. The haystack and label can
+      // diverge (e.g. label "Settings · X" vs haystack "settings x ...") which
+      // previously shifted the bolded characters onto the " · " separator.
+      const labelMatch = fuzzyMatch(q, it.label.toLowerCase())
+      scored.push({ item: it, positions: labelMatch ? labelMatch.positions : [], score: m.score })
     }
     scored.sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score
@@ -571,7 +578,7 @@ export default function CommandPalette() {
                     <button
                       key={entry.item.id}
                       data-idx={idx}
-                      onMouseEnter={() => setActiveIdx(idx)}
+                      onMouseMove={() => setActiveIdx(idx)}
                       onClick={() => { entry.item.perform(); closePalette() }}
                       className={`w-full text-left px-3 py-2 flex items-center gap-3 transition-colors ${
                         active ? 'bg-surface-2 text-text-primary' : 'text-text-muted hover:bg-surface-2/60'

--- a/frontend/src/components/DebInstallModal.tsx
+++ b/frontend/src/components/DebInstallModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import Convert from 'ansi-to-html'
 import { servers as serversApi, createInstallDebWebSocket } from '@/api/client'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 const ansiConvert = new Convert({ escapeXML: true })
 
@@ -32,6 +33,8 @@ export default function DebInstallModal({ serverId, onClose }: Props) {
   const [success, setSuccess] = useState<boolean | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
   const termRef = useRef<HTMLDivElement>(null)
+  const mountedRef = useRef(true)
+  const uploadAbortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     if (termRef.current) {
@@ -40,13 +43,21 @@ export default function DebInstallModal({ serverId, onClose }: Props) {
   }, [lines])
 
   useEffect(() => {
-    return () => { wsRef.current?.close() }
+    return () => {
+      mountedRef.current = false
+      wsRef.current?.close()
+      uploadAbortRef.current?.abort()
+    }
   }, [])
 
   function handleClose() {
+    uploadAbortRef.current?.abort()
     wsRef.current?.close()
     onClose()
   }
+
+  // Escape closes the modal (matches the always-available Cancel/Close button).
+  useEscapeKey(handleClose)
 
   async function handleValidate() {
     if (!url.trim()) return
@@ -101,12 +112,17 @@ export default function DebInstallModal({ serverId, onClose }: Props) {
     setLines([])
     setSuccess(null)
 
+    const controller = new AbortController()
+    uploadAbortRef.current = controller
+
     let remotePath: string
     try {
-      const result = await serversApi.uploadDeb(serverId, file)
+      const result = await serversApi.uploadDeb(serverId, file, controller.signal)
+      if (!mountedRef.current) return   // modal closed mid-upload — don't install on a dead component
       remotePath = result.remote_path
       setUploadProgress(null)
     } catch (e: unknown) {
+      if (!mountedRef.current) return   // aborted by close — nothing to report
       setUploadProgress(null)
       setLines([`Upload failed: ${e}`])
       setPhase('done')
@@ -159,7 +175,12 @@ export default function DebInstallModal({ serverId, onClose }: Props) {
               {(['url', 'upload'] as Mode[]).map(m => (
                 <button
                   key={m}
-                  onClick={() => { setMode(m); setValidationResult(null); setFile(null) }}
+                  onClick={() => {
+                    setMode(m)
+                    // Only reset the state for the mode being left, so switching tabs
+                    // and back doesn't discard a completed URL validation or chosen file.
+                    if (m === 'url') setFile(null); else setValidationResult(null)
+                  }}
                   disabled={busy}
                   className={`px-4 py-2 text-sm -mb-px border-b-2 transition-colors ${
                     mode === m ? 'border-green text-text-primary' : 'border-transparent text-text-muted hover:text-text-primary'

--- a/frontend/src/components/PackageInstallModal.tsx
+++ b/frontend/src/components/PackageInstallModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { servers as serversApi, createInstallWebSocket } from '@/api/client'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
 import type { PackageSearchResult } from '@/types'
 import Convert from 'ansi-to-html'
 
@@ -62,6 +63,9 @@ export default function PackageInstallModal({ serverId, serverName, onClose }: P
   useEffect(() => {
     return () => { wsRef.current?.close() }
   }, [])
+
+  // Escape closes the modal when it's safe to (before start or once done).
+  useEscapeKey(handleClose, !started || done)
 
   function toggleSelect(name: string) {
     setSelected(prev => {

--- a/frontend/src/components/PackageInstallModal.tsx
+++ b/frontend/src/components/PackageInstallModal.tsx
@@ -24,6 +24,7 @@ export default function PackageInstallModal({ serverId, serverName, onClose }: P
   const [results, setResults] = useState<PackageSearchResult[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [searching, setSearching] = useState(false)
+  const [started, setStarted] = useState(false)
   const [installing, setInstalling] = useState(false)
   const [termLines, setTermLines] = useState<string[]>([])
   const [done, setDone] = useState(false)
@@ -31,6 +32,7 @@ export default function PackageInstallModal({ serverId, serverName, onClose }: P
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const termRef = useRef<HTMLDivElement>(null)
   const wsRef = useRef<WebSocket | null>(null)
+  const completedRef = useRef(false)
 
   const doSearch = useCallback(async (q: string) => {
     if (!q.trim()) { setResults([]); return }
@@ -72,23 +74,36 @@ export default function PackageInstallModal({ serverId, serverName, onClose }: P
 
   function startInstall() {
     if (selected.size === 0) return
+    setStarted(true)
     setInstalling(true)
     setTermLines([])
     setDone(false)
     setError('')
+    completedRef.current = false
 
     const ws = createInstallWebSocket(serverId, Array.from(selected), (msg) => {
       if (msg.type === 'output') {
         setTermLines(l => [...l, msg.data as string])
       } else if (msg.type === 'complete') {
+        completedRef.current = true
         setDone(true)
         window.dispatchEvent(new CustomEvent('apt:refresh'))
       } else if (msg.type === 'error') {
+        completedRef.current = true
         setError(msg.data as string)
         setDone(true)
       }
-    }, () => {
+    }, (ev) => {
       setInstalling(false)
+      // The socket closing is NOT completion — only a 'complete'/'error' message is.
+      // If it closes first (auth drop, network), surface it instead of silently
+      // snapping back to the empty search view.
+      if (!completedRef.current) {
+        setError(prev => prev || (ev && !ev.wasClean
+          ? 'Connection closed before the install finished — check the server.'
+          : 'Install ended without a completion message.'))
+        setDone(true)
+      }
     })
     wsRef.current = ws
   }
@@ -101,18 +116,18 @@ export default function PackageInstallModal({ serverId, serverName, onClose }: P
   const modal = (
     <div
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
-      onClick={e => { if (e.target === e.currentTarget) handleClose() }}
+      onClick={e => { if (e.target === e.currentTarget) { e.stopPropagation(); handleClose() } }}
     >
       <div className="bg-surface border border-border rounded-lg w-full max-w-2xl max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
         {/* Header */}
         <div className="p-4 border-b border-border flex items-center justify-between">
           <h2 className="font-mono text-sm text-text-primary">Install Packages — {serverName}</h2>
-          {(!installing || done) && (
+          {(!started || done) && (
             <button onClick={handleClose} className="text-text-muted hover:text-red">✕</button>
           )}
         </div>
 
-        {!installing ? (
+        {!started ? (
           <div className="flex flex-col flex-1 overflow-hidden p-4 gap-3">
             {/* Search input */}
             <div className="relative">

--- a/frontend/src/components/RollingRebootModal.tsx
+++ b/frontend/src/components/RollingRebootModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useMemo } from 'react'
 import type { Server, ScheduleConfig } from '@/types'
 import { createRebootAllWebSocket, scheduler as schedulerApi } from '@/api/client'
 import { useJobStore } from '@/hooks/useJobStore'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
 
 interface Props {
   servers: Server[]
@@ -56,6 +57,9 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
     schedulerApi.status().then(setCfg).catch(() => {})
     return () => { wsRef.current?.close() }
   }, [])
+
+  // Escape closes the modal before start or once done (not mid-rollout).
+  useEscapeKey(handleClose, !started || done)
 
   const rings = useMemo(() => groupByRing(servers), [servers])
   const ringNames = useMemo(() => Object.keys(rings).sort(), [rings])

--- a/frontend/src/components/RollingRebootModal.tsx
+++ b/frontend/src/components/RollingRebootModal.tsx
@@ -34,6 +34,9 @@ function groupByRing(servers: Server[]): Record<string, Server[]> {
 
 export default function RollingRebootModal({ servers, onClose }: Props) {
   const [started, setStarted] = useState(false)
+  // Snapshot of targets at start() so the dashboard poll mutating the live `servers`
+  // prop can't make rows vanish from the running view mid-reboot.
+  const [runServers, setRunServers] = useState<Server[]>([])
   const [progress, setProgress] = useState<Record<number, ServerProgress>>({})
   const [done, setDone] = useState(false)
   const [filterServer, setFilterServer] = useState<number | null>(null)
@@ -47,6 +50,7 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
   const wsRef = useRef<WebSocket | null>(null)
   const { addJob, updateJob } = useJobStore()
   const completedRef = useRef(0)
+  const abortedRef = useRef(false)
 
   useEffect(() => {
     schedulerApi.status().then(setCfg).catch(() => {})
@@ -61,16 +65,19 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
   const timeoutMinutes = cfg?.reboot_timeout_minutes ?? 10
 
   function start() {
+    const snapshot = servers
     setStarted(true)
+    setRunServers(snapshot)
     completedRef.current = 0
+    abortedRef.current = false
     const initial: Record<number, ServerProgress> = {}
-    servers.forEach(s => { initial[s.id] = { phase: 'pending' } })
+    snapshot.forEach(s => { initial[s.id] = { phase: 'pending' } })
     setProgress(initial)
 
     addJob({
       id: 'reboot-all',
       type: 'upgrade-all',
-      label: `Rolling Reboot (${servers.length} servers)`,
+      label: `Rolling Reboot (${snapshot.length} servers)`,
       status: 'running',
       link: '/',
       startedAt: Date.now(),
@@ -112,6 +119,7 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
       }
       if (t === 'abort') {
         const data = msg.data as { ring: string; reason: string }
+        abortedRef.current = true
         setAborted(true)
         setAbortReason(data.reason)
         setLogs(l => [...l, `[abort] ring ${data.ring}: ${data.reason}`])
@@ -139,7 +147,24 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
         setProgress(p => ({ ...p, [sid]: { phase: 'error', message: msg.data as string } }))
         completedRef.current += 1
       }
-    }, () => setDone(true))
+    }, (ev) => {
+      setDone(true)
+      // If the socket dropped before every server came back (and we didn't already
+      // abort), mark the unfinished servers as errored rather than implying success.
+      if (!abortedRef.current && completedRef.current < snapshot.length) {
+        updateJob('reboot-all', { status: 'error', completedAt: Date.now() })
+        const note = ev && !ev.wasClean ? 'connection closed before completion' : 'stream ended early'
+        setProgress(p => {
+          const next: Record<number, ServerProgress> = {}
+          for (const [k, v] of Object.entries(p)) {
+            next[+k] = (v.phase === 'pending' || v.phase === 'rebooting' || v.phase === 'waiting')
+              ? { phase: 'error', message: note }
+              : v
+          }
+          return next
+        })
+      }
+    }, { server_ids: snapshot.map(s => s.id) })
 
     wsRef.current = ws
   }
@@ -243,7 +268,7 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
               >
                 All
               </button>
-              {servers.map(s => {
+              {runServers.map(s => {
                 const p = progress[s.id]
                 const phase: RebootPhase = p?.phase ?? 'pending'
                 const active = filterServer === s.id
@@ -269,7 +294,7 @@ export default function RollingRebootModal({ servers, onClose }: Props) {
               className="flex-1 overflow-y-auto bg-bg border border-border rounded p-2 font-mono text-xs text-text-primary min-h-0"
               style={{ maxHeight: '40vh' }}
             >
-              {servers
+              {runServers
                 .filter(s => filterServer === null || filterServer === s.id)
                 .map(s => {
                   const p = progress[s.id]

--- a/frontend/src/components/UpgradeAllModal.tsx
+++ b/frontend/src/components/UpgradeAllModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import type { Server } from '@/types'
 import { createUpgradeWebSocket } from '@/api/client'
 import { useJobStore } from '@/hooks/useJobStore'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
 import Convert from 'ansi-to-html'
 
 const ansiConvert = new Convert({ escapeXML: true })
@@ -49,6 +50,9 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
   useEffect(() => {
     return () => { wsRef.current?.close() }
   }, [])
+
+  // Escape closes the modal before start or once the run is done (not mid-run).
+  useEscapeKey(handleClose, !started || done)
 
   function start() {
     const snapshot = servers

--- a/frontend/src/components/UpgradeAllModal.tsx
+++ b/frontend/src/components/UpgradeAllModal.tsx
@@ -33,6 +33,9 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
   const [allowPhased, setAllowPhased] = useState(false)
   const [rebootIfRequired, setRebootIfRequired] = useState(false)
   const [started, setStarted] = useState(false)
+  // Snapshot of the target servers taken at start(); the running view renders from this
+  // so the 30s dashboard poll mutating the live `servers` prop can't make rows vanish.
+  const [runServers, setRunServers] = useState<Server[]>([])
   const [progress, setProgress] = useState<Record<number, ServerProgress>>({})
   const [done, setDone] = useState(false)
   const [filterServer, setFilterServer] = useState<number | null>(null)
@@ -48,23 +51,27 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
   }, [])
 
   function start() {
+    const snapshot = servers
     setStarted(true)
-    pendingRef.current = servers.length
+    setRunServers(snapshot)
+    pendingRef.current = snapshot.length
     const initial: Record<number, ServerProgress> = {}
-    servers.forEach(s => { initial[s.id] = { status: 'pending', lines: [] } })
+    snapshot.forEach(s => { initial[s.id] = { status: 'pending', lines: [] } })
     setProgress(initial)
 
     addJob({
       id: 'upgrade-all',
       type: 'upgrade-all',
-      label: `Upgrade All (${servers.length} servers)`,
+      label: `Upgrade All (${snapshot.length} servers)`,
       status: 'running',
       link: '/',
       action: 'restore-upgrade-all',
       startedAt: Date.now(),
     })
 
-    const ws = createUpgradeWebSocket('all', { action, allow_phased: allowPhased, reboot_if_required: rebootIfRequired }, (msg) => {
+    // Send the explicit target ids so the backend upgrades exactly the filtered set,
+    // not every enabled server. Without this, "Upgrade All (3)" upgraded the whole fleet.
+    const ws = createUpgradeWebSocket('all', { action, allow_phased: allowPhased, reboot_if_required: rebootIfRequired, server_ids: snapshot.map(s => s.id) }, (msg) => {
       const sid = msg.server_id as number
       if (!sid) return
 
@@ -95,7 +102,27 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
           updateJob('upgrade-all', { status: 'error', completedAt: Date.now(), action: undefined })
         }
       }
-    }, () => setDone(true))
+    }, (ev) => {
+      setDone(true)
+      // If the socket closed before every server reported back, the run did NOT fully
+      // succeed — mark the stragglers as errored instead of showing a clean "Done".
+      if (pendingRef.current > 0) {
+        pendingRef.current = 0
+        updateJob('upgrade-all', { status: 'error', completedAt: Date.now(), action: undefined })
+        const note = ev && !ev.wasClean
+          ? '✗ Connection closed before this server finished.'
+          : '✗ Stream ended without a completion message.'
+        setProgress(p => {
+          const next: Record<number, ServerProgress> = {}
+          for (const [k, v] of Object.entries(p)) {
+            next[+k] = (v.status === 'pending' || v.status === 'running')
+              ? { ...v, status: 'error', lines: [...v.lines, note] }
+              : v
+          }
+          return next
+        })
+      }
+    })
 
     wsRef.current = ws
   }
@@ -223,7 +250,7 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
               >
                 All
               </button>
-              {servers.map(s => {
+              {runServers.map(s => {
                 const p = progress[s.id]
                 const active = filterServer === s.id
                 const borderColor =
@@ -253,7 +280,7 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
               className="flex-1 overflow-y-auto bg-bg border border-border rounded p-2 font-mono text-xs text-text-primary min-h-0"
               style={{ maxHeight: '40vh' }}
             >
-              {servers.flatMap(s => {
+              {runServers.flatMap(s => {
                 if (filterServer !== null && filterServer !== s.id) return []
                 return (progress[s.id]?.lines || []).map((line, i) => (
                   <div key={`${s.id}-${i}`}>

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -31,6 +31,9 @@ export const useAuthStore = create<AuthState>((set) => ({
   logout: async () => {
     await auth.logout()
     set({ user: null })
+    // Clear per-user device-local state so it doesn't leak to the next user on a
+    // shared browser (e.g. the command palette's recently-visited servers).
+    try { localStorage.removeItem('palette:recentServers') } catch {}
     window.location.href = '/login'
   },
 }))

--- a/frontend/src/hooks/useEscapeKey.ts
+++ b/frontend/src/hooks/useEscapeKey.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+/**
+ * Calls `handler` when Escape is pressed, while `enabled` is true.
+ * Used by modals so Escape closes them (gated so it can't interrupt an in-flight
+ * operation). Listener is cleaned up on unmount / when disabled.
+ */
+export function useEscapeKey(handler: () => void, enabled = true) {
+  useEffect(() => {
+    if (!enabled) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        handler()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [handler, enabled])
+}

--- a/frontend/src/hooks/useJobStore.ts
+++ b/frontend/src/hooks/useJobStore.ts
@@ -49,6 +49,10 @@ export const useJobStore = create<JobStore>()(
 
         set((s) => ({
           jobs: s.jobs.map(j => (j.id === id ? { ...j, ...update } : j)),
+          // Surface the amber "unseen completion" dot. Reset by markSeen() when the
+          // bell is opened — not by the auto-remove below, so the dot survives the
+          // 3s removal and still signals that something finished.
+          unseenCount: finishing ? s.unseenCount + 1 : s.unseenCount,
         }))
 
         if (finishing) {
@@ -57,14 +61,9 @@ export const useJobStore = create<JobStore>()(
       },
 
       removeJob: (id) =>
-        set((s) => {
-          const job = s.jobs.find(j => j.id === id)
-          const wasUnseen = job && job.status !== 'running'
-          return {
-            jobs: s.jobs.filter(j => j.id !== id),
-            unseenCount: wasUnseen ? Math.max(0, s.unseenCount - 1) : s.unseenCount,
-          }
-        }),
+        set((s) => ({
+          jobs: s.jobs.filter(j => j.id !== id),
+        })),
 
       markSeen: () => set({ unseenCount: 0 }),
     }),

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -47,6 +47,13 @@ export default function Compare() {
     }
   }
 
+  // Servers that actually returned data. Errored servers are listed in result.servers
+  // but omitted from each package's versions map, so they must NOT count toward the
+  // "present on every server" denominator — otherwise every package looks diverged.
+  const respondingCount = result
+    ? result.servers.length - Object.keys(result.errors).length
+    : 0
+
   // Derive filtered package list
   const filteredPackages = result
     ? Object.entries(result.packages).filter(([name, versions]) => {
@@ -55,7 +62,7 @@ export default function Compare() {
         const vals = Object.values(versions)
         if (filter === 'diff') {
           const nonNull = vals.filter(v => v != null)
-          return nonNull.length > 0 && nonNull.length < result.servers.length
+          return nonNull.length > 0 && nonNull.length < respondingCount
         }
         if (filter === 'common') {
           return vals.every(v => v != null)
@@ -68,7 +75,7 @@ export default function Compare() {
     ? Object.values(result.packages).filter(versions => {
         const vals = Object.values(versions)
         const nonNull = vals.filter(v => v != null)
-        return nonNull.length > 0 && nonNull.length < result.servers.length
+        return nonNull.length > 0 && nonNull.length < respondingCount
       }).length
     : 0
 
@@ -208,7 +215,7 @@ export default function Compare() {
                 ) : (
                   filteredPackages.map(([name, versions]) => {
                     const presentCount = Object.values(versions).filter(v => v != null).length
-                    const isDiff = presentCount < result.servers.length
+                    const isDiff = presentCount < respondingCount
                     return (
                       <tr key={name} className={isDiff ? 'bg-amber/5' : ''}>
                         <td className="px-3 py-1.5 text-text-primary sticky left-0 bg-inherit z-10">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1174,8 +1174,11 @@ function HitBar({ pct }: { pct: number }) {
 }
 
 function AptCacheCard({ s }: { s: AptCacheStats }) {
-  const today = s.daily[0] as AptCacheDailyRow | undefined
-  const shown = s.daily.slice(0, 7)
+  // `daily` is absent when the apt-cacher-ng server is unreachable (backend returns
+  // { ok: false } with no daily key); guard so the card renders the offline state
+  // instead of throwing a TypeError that blanks the whole page (no error boundary).
+  const today = (s.daily ?? [])[0] as AptCacheDailyRow | undefined
+  const shown = (s.daily ?? []).slice(0, 7)
 
   return (
     <div className="card p-3 space-y-3">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -171,9 +171,11 @@ export default function Dashboard() {
     return () => window.removeEventListener('apt:refresh', handler)
   }, [load])
 
-  // Reachability: single endpoint with server-side TTL caching
+  // Reachability: single endpoint with server-side TTL caching. usePolling already
+  // does the initial load() on mount, so we only kick off the ping cycle here
+  // (pingAll hits its own endpoint and doesn't depend on the server list load).
   useEffect(() => {
-    load().then(() => pingAll())
+    pingAll()
     const id = setInterval(() => pingAll(), 5 * 60_000)
     return () => clearInterval(id)
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -386,10 +388,13 @@ export default function Dashboard() {
                 <button
                   key={label}
                   onClick={() => {
-                    setStatusFilter(statusFilter === filter ? null : filter)
-                    if (opensModal) setShowUpdatesSummary(true)
-                    if (opensAutoremove) setShowAutoremoveAll(true)
-                    if (opensRollingReboot) setShowRollingReboot(true)
+                    // Only open the modal when the click activates the filter — clicking
+                    // an already-active tile clears the filter and should not re-open it.
+                    const willActivate = statusFilter !== filter
+                    setStatusFilter(willActivate ? filter : null)
+                    if (willActivate && opensModal) setShowUpdatesSummary(true)
+                    if (willActivate && opensAutoremove) setShowAutoremoveAll(true)
+                    if (willActivate && opensRollingReboot) setShowRollingReboot(true)
                   }}
                   className={`card px-3 py-2 text-center cursor-pointer hover:border-text-muted transition-colors ${statusFilter === filter ? 'border-green/50 bg-green/5' : ''}`}
                   style={{ minWidth: 72 }}
@@ -587,10 +592,16 @@ export default function Dashboard() {
               ) : 'No servers match your filter.'}
             </div>
           )}
-          {Array.from(new Map(
-            filtered.map(s => [s.group_name ?? null, s.group_color ?? null])
-          ).entries()).map(([groupName, groupColor]) => {
-            const groupServers = filtered.filter(s => (s.group_name ?? null) === groupName)
+          {(() => {
+            // When filtering by a specific group, render a single section for it.
+            // Bucketing by the legacy group_name would file multi-group servers under
+            // their primary group, contradicting the active (any-membership) filter.
+            const activeGroupObj = activeGroup != null ? groupList.find(g => g.id === activeGroup) : null
+            const buckets: [string | null, string | null][] = activeGroupObj
+              ? [[activeGroupObj.name, activeGroupObj.color ?? null]]
+              : Array.from(new Map(filtered.map(s => [s.group_name ?? null, s.group_color ?? null])).entries())
+            return buckets.map(([groupName, groupColor]) => {
+            const groupServers = activeGroupObj ? filtered : filtered.filter(s => (s.group_name ?? null) === groupName)
             return (
               <div key={groupName ?? 'ungrouped'}>
                 <div className="flex items-center gap-2 mb-2">
@@ -612,7 +623,8 @@ export default function Dashboard() {
                 </div>
               </div>
             )
-          })}
+            })
+          })()}
         </div>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
@@ -942,9 +954,9 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable }
             <span className="font-mono text-sm text-text-primary truncate">{s.name}</span>
           </div>
           <div className="flex items-center font-mono text-xs text-text-muted truncate group/host">
-            {reachable === false && <span title="Unreachable" className="w-2 h-2 rounded-full bg-red inline-block mr-1 shrink-0" />}
-            {reachable === true && <span title="Reachable" className="w-2 h-2 rounded-full bg-green inline-block mr-1 shrink-0" />}
-            {(reachable === null || reachable === undefined) && <span className="w-2 h-2 rounded-full bg-gray-600 inline-block mr-1 shrink-0" />}
+            {reachable === false && <span title="SSH unreachable" className="w-2 h-2 rounded-full bg-red inline-block mr-1 shrink-0" />}
+            {reachable === true && <span title="SSH OK" className="w-2 h-2 rounded-full bg-green inline-block mr-1 shrink-0" />}
+            {(reachable === null || reachable === undefined) && <span title="SSH status unknown" className="w-2 h-2 rounded-full bg-gray-600 inline-block mr-1 shrink-0" />}
             <span className="truncate">{s.hostname}</span>
             <span className="ml-1.5 opacity-0 group-hover/host:opacity-100 transition-opacity shrink-0" onClick={e => e.stopPropagation()}>
               <CopySshButton username={s.username} hostname={s.hostname} port={s.ssh_port} />

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -232,7 +232,7 @@ function NotificationHistory() {
   }
 
   const channelBadge = (ch: string) => {
-    const map: Record<string, string> = { email: 'text-blue', telegram: 'text-cyan', webhook: 'text-purple' }
+    const map: Record<string, string> = { email: 'text-blue', telegram: 'text-cyan', webhook: 'text-purple', slack: 'text-amber' }
     return <span className={`text-[10px] font-mono uppercase tracking-wide ${map[ch] ?? 'text-text-muted'}`}>{ch}</span>
   }
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 import { auth } from '@/api/client'
 import { useAuthStore } from '@/hooks/useAuth'
 
@@ -12,12 +12,15 @@ export default function Login() {
   const [loading, setLoading] = useState(false)
   const { setUser, user } = useAuthStore()
   const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams] = useSearchParams()
   const expired = searchParams.get('expired') === '1'
+  // RequireAuth stashes the page the user originally tried to reach in location.state.from.
+  const from = (location.state as { from?: { pathname?: string } } | null)?.from?.pathname || '/'
 
   useEffect(() => {
-    if (user) navigate('/', { replace: true })
-  }, [user, navigate])
+    if (user) navigate(from, { replace: true })
+  }, [user, navigate, from])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -26,7 +29,7 @@ export default function Login() {
     try {
       const u = await auth.login(username, password, needs2fa ? totpCode : undefined)
       setUser(u)
-      navigate('/', { replace: true })
+      navigate(from, { replace: true })
     } catch (err: unknown) {
       const msg = (err as Error).message || 'Login failed'
       // Backend signals 2FA needed via the error detail (issue #18)

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,8 +15,11 @@ export default function Login() {
   const location = useLocation()
   const [searchParams] = useSearchParams()
   const expired = searchParams.get('expired') === '1'
-  // RequireAuth stashes the page the user originally tried to reach in location.state.from.
-  const from = (location.state as { from?: { pathname?: string } } | null)?.from?.pathname || '/'
+  // RequireAuth stashes the full location the user originally tried to reach in
+  // location.state.from — preserve its search/hash too so deep links like
+  // /settings?tab=Users land on the right tab after login, not just the pathname.
+  const fromLoc = (location.state as { from?: { pathname?: string; search?: string; hash?: string } } | null)?.from
+  const from = fromLoc ? `${fromLoc.pathname ?? '/'}${fromLoc.search ?? ''}${fromLoc.hash ?? ''}` : '/'
 
   useEffect(() => {
     if (user) navigate(from, { replace: true })

--- a/frontend/src/pages/ServerDetail.tsx
+++ b/frontend/src/pages/ServerDetail.tsx
@@ -77,8 +77,11 @@ export default function ServerDetail() {
       const s = list.find(x => x.id === serverId) || null
       setServer(s)
       setGroupList(glist)
-    } finally {
+      // Only mark loaded on a successful fetch, so a transient/network error keeps
+      // showing "Loading…" rather than a misleading "Server not found".
       setLoaded(true)
+    } catch {
+      // Swallow so the effect's load() doesn't produce an unhandled rejection.
     }
   }, [serverId])
 

--- a/frontend/src/pages/ServerDetail.tsx
+++ b/frontend/src/pages/ServerDetail.tsx
@@ -61,6 +61,7 @@ export default function ServerDetail() {
   const location = useLocation()
 
   const [server, setServer] = useState<Server | null>(null)
+  const [loaded, setLoaded] = useState(false)
   const [groupList, setGroupList] = useState<ServerGroup[]>([])
   const [tab, setTab] = useState<Tab>('Packages')
   const [checking, setChecking] = useState(false)
@@ -71,10 +72,14 @@ export default function ServerDetail() {
   const { addJob, updateJob } = useJobStore()
 
   const load = useCallback(async () => {
-    const [list, glist] = await Promise.all([serversApi.list(), groupsApi.list()])
-    const s = list.find(x => x.id === serverId) || null
-    setServer(s)
-    setGroupList(glist)
+    try {
+      const [list, glist] = await Promise.all([serversApi.list(), groupsApi.list()])
+      const s = list.find(x => x.id === serverId) || null
+      setServer(s)
+      setGroupList(glist)
+    } finally {
+      setLoaded(true)
+    }
   }, [serverId])
 
   useEffect(() => { load() }, [load])
@@ -125,9 +130,19 @@ export default function ServerDetail() {
     }
   }
 
-  if (!server) return (
-    <div className="flex items-center justify-center py-20 text-text-muted font-mono text-sm">Loading…</div>
-  )
+  if (!server) {
+    // Distinguish "still fetching" from "no such server" (bad/non-numeric/deleted id)
+    // so an unknown /servers/:id doesn't spin forever.
+    if (!loaded && !Number.isNaN(serverId)) return (
+      <div className="flex items-center justify-center py-20 text-text-muted font-mono text-sm">Loading…</div>
+    )
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-3 text-text-muted font-mono text-sm">
+        <span>Server not found.</span>
+        <Link to="/" className="text-green hover:underline">← Back to dashboard</Link>
+      </div>
+    )
+  }
 
   const c = server.latest_check
   const statusVal = checking ? 'checking' : (!c ? 'unknown' : c.status === 'error' ? 'error' : c.packages_available > 0 ? 'updates_available' : 'up_to_date')
@@ -293,6 +308,13 @@ function EditServerForm({ server, groupList, onSaved, onCancel }: {
 
   useEffect(() => {
     tagsApi.list().then(setTagList)
+  }, [])
+
+  // Close any in-flight per-form streams on unmount (Cancel edit / Save / navigate away).
+  useEffect(() => () => {
+    eepromWsRef.current?.close()
+    autoSecWsRef.current?.close()
+    aptProxyWsRef.current?.close()
   }, [])
 
   useEffect(() => {
@@ -1363,7 +1385,7 @@ function UpgradePanel({ serverId, server, onRefresh }: { serverId: number; serve
   const dryTermRef = useRef<HTMLDivElement>(null)
   const { addJob, updateJob } = useJobStore()
 
-  useEffect(() => () => { wsRef.current?.close(); dryWsRef.current?.close() }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => () => { wsRef.current?.close(); dryWsRef.current?.close(); pveWsRef.current?.close() }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Detect container-runtime packages in the upgrade list
   useEffect(() => {
@@ -1634,12 +1656,14 @@ function SshShellPanel({ serverId }: { serverId: number }) {
   const termRef = useRef<any>(null)   // Terminal instance
   const fitRef = useRef<any>(null)    // FitAddon instance
   const wsRef = useRef<WebSocket | null>(null)
+  const roRef = useRef<ResizeObserver | null>(null)
   const [status, setStatus] = useState<'idle' | 'connecting' | 'connected' | 'disconnected'>('idle')
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     return () => {
       wsRef.current?.close()
+      roRef.current?.disconnect()
       termRef.current?.dispose()
     }
   }, [])
@@ -1651,6 +1675,7 @@ function SshShellPanel({ serverId }: { serverId: number }) {
 
     // Dispose any existing session
     wsRef.current?.close()
+    roRef.current?.disconnect()
     if (termRef.current) {
       termRef.current.dispose()
       termRef.current = null
@@ -1683,6 +1708,7 @@ function SshShellPanel({ serverId }: { serverId: number }) {
 
     const ro = new ResizeObserver(() => fitRef.current?.fit())
     ro.observe(containerRef.current)
+    roRef.current = ro
 
     const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/api/ws/shell/${serverId}`
     const ws = new WebSocket(url)
@@ -1841,7 +1867,7 @@ function StatsTab({ serverId }: { serverId: number }) {
   return (
     <div className="space-y-4">
       <div className="card p-4">
-        <h3 className="text-xs text-text-muted uppercase tracking-wide mb-4">Packages upgraded per run (last 30)</h3>
+        <h3 className="text-xs text-text-muted uppercase tracking-wide mb-4">Packages upgraded per run (recent)</h3>
         <ResponsiveContainer width="100%" height={200}>
           <LineChart data={data}>
             <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
@@ -1850,7 +1876,7 @@ function StatsTab({ serverId }: { serverId: number }) {
               contentStyle={{ background: '#1a1d27', border: '1px solid #2e3347', borderRadius: '4px', fontSize: '12px' }}
               labelStyle={{ color: '#e5e7eb' }}
             />
-            <Line type="monotone" dataKey="packages" stroke="#22c55e" dot={false} strokeWidth={1.5} />
+            <Line type="monotone" dataKey="packages" stroke="#22c55e" dot={data.length <= 2} strokeWidth={1.5} />
           </LineChart>
         </ResponsiveContainer>
       </div>
@@ -2156,6 +2182,11 @@ function AptReposTab({ serverId }: { serverId: number }) {
         setTestResult(false)
         setTesting(false)
       }
+    }, () => {
+      // Socket closed: clear the spinner, and if no complete/error arrived
+      // (auth drop / dropped connection) surface it as a failure.
+      setTesting(false)
+      setTestResult(prev => (prev === null ? false : prev))
     })
   }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1579,20 +1579,14 @@ function CalendarSubscribeModal({ onClose }: { onClose: () => void }) {
             </form>
           ) : !createdToken ? (
             <div className="space-y-2">
-              <label className="label">Use existing API token</label>
-              <select
-                value={selectedId ?? ''}
-                onChange={e => setSelectedId(e.target.value ? parseInt(e.target.value) : null)}
-                className="input text-sm"
-              >
-                {tokens.map(t => (
-                  <option key={t.id} value={t.id}>{t.name} ({t.prefix}…)</option>
-                ))}
-              </select>
+              <p className="text-xs text-text-muted">
+                You have {tokens.length} existing API token{tokens.length === 1 ? '' : 's'}
+                {tokens.length > 0 && <> ({tokens.map(t => `${t.prefix}…`).join(', ')})</>}.
+              </p>
               <p className="text-[10px] text-amber/80 mt-1">
-                The raw token value is shown only once at creation — paste yours into the URL below
-                in place of <span className="font-mono">&lt;paste-your-api-token-here&gt;</span>.
-                If you don&apos;t have it saved, mint a new token below.
+                A token&apos;s raw value is shown only once at creation and can&apos;t be retrieved here.
+                If you saved an existing one, paste it into the URL below in place of
+                <span className="font-mono"> &lt;paste-your-api-token-here&gt;</span> — otherwise mint a new token.
               </p>
               <form onSubmit={createToken} className="flex items-center gap-2 pt-2 border-t border-border/30">
                 <input

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { useSearchParams } from 'react-router-dom'
 import { servers as serversApi, groups as groupsApi, tags as tagsApi, scheduler as schedulerApi, notifications as notifApi, auth, config as configApi, aptcache as aptcacheApi, tailscale as tailscaleApi, maintenance as maintenanceApi, hooks as hooksApi } from '@/api/client'
 import type { MaintenanceWindow, UpgradeHook } from '@/api/client'
 import type { Server, ServerGroup, ScheduleConfig, NotificationConfig, Tag, AptCacheServer, TailscaleStatus } from '@/types'
@@ -29,24 +30,19 @@ function pickDistinctColor(existingColors: string[]): string {
 export default function Settings() {
   const { user } = useAuthStore()
 
-  // Initial tab can be supplied via ?tab=<name> — used by the command palette
-  // and other deep links. Falls back to 'Servers' for any unknown value.
-  const initialTab: Tab = (() => {
-    const param = new URLSearchParams(window.location.search).get('tab')
-    if (param && (TABS as readonly string[]).includes(param)) return param as Tab
-    return 'Servers'
-  })()
-  const [tab, setTab] = useState<Tab>(initialTab)
-
-  // Re-sync if the query string changes (e.g. user opens the palette twice)
-  useEffect(() => {
-    function onPopState() {
-      const param = new URLSearchParams(window.location.search).get('tab')
-      if (param && (TABS as readonly string[]).includes(param)) setTab(param as Tab)
-    }
-    window.addEventListener('popstate', onPopState)
-    return () => window.removeEventListener('popstate', onPopState)
-  }, [])
+  // The active tab is driven by ?tab=<name> so deep links (command palette, etc.)
+  // re-sync on every navigation — not just on popstate. Previously a react-router
+  // navigate() to /settings?tab=Users while already on /settings left the tab stuck.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const tabParam = searchParams.get('tab')
+  const tab: Tab = (tabParam && (TABS as readonly string[]).includes(tabParam)) ? (tabParam as Tab) : 'Servers'
+  const setTab = (t: Tab) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev)
+      next.set('tab', t)
+      return next
+    }, { replace: true })
+  }
 
   // Hide admin-only tabs for read-only users
   const visibleTabs = TABS.filter(t => {
@@ -1953,12 +1949,12 @@ function PreferencesTab() {
         <h2 className="text-sm font-medium text-text-primary">Concurrency & Retention</h2>
         <div>
           <label className="label">Max simultaneous upgrades</label>
-          <input type="number" className="input w-24" min={1} max={20} value={form.upgrade_concurrency ?? 5} onChange={e => setForm(f => ({ ...f, upgrade_concurrency: parseInt(e.target.value) }))} />
+          <input type="number" className="input w-24" min={1} max={20} value={form.upgrade_concurrency ?? 5} onChange={e => setForm(f => ({ ...f, upgrade_concurrency: parseInt(e.target.value) || 5 }))} />
           <p className="text-xs text-text-muted mt-1">Applies to both manual "Upgrade All" and auto-upgrades.</p>
         </div>
         <div>
           <label className="label">Log retention (days, 0 = forever)</label>
-          <input type="number" className="input w-24" min={0} value={form.log_retention_days ?? 90} onChange={e => setForm(f => ({ ...f, log_retention_days: parseInt(e.target.value) }))} />
+          <input type="number" className="input w-24" min={0} value={form.log_retention_days ?? 90} onChange={e => { const n = parseInt(e.target.value); setForm(f => ({ ...f, log_retention_days: Number.isNaN(n) ? 0 : n })) }} />
           <p className="text-xs text-text-muted mt-1">Check history and upgrade logs older than this are purged nightly.</p>
         </div>
       </section>
@@ -2150,8 +2146,18 @@ function NotificationsTab() {
     }
   }
 
+  // Test/detect endpoints read the persisted DB config, so save the current form
+  // first — otherwise they silently test stale or empty saved credentials. The
+  // backend ignores masked secret placeholders, so unchanged secrets are preserved.
+  async function persistForm() {
+    const updated = await notifApi.updateConfig(form)
+    setCfg(updated)
+    setForm(updated)
+  }
+
   async function sendTestEmail() {
     try {
+      await persistForm()
       await notifApi.testEmail()
       setTestMsg(m => ({ ...m, email: '✓ Test email sent' }))
     } catch (err: unknown) {
@@ -2161,6 +2167,7 @@ function NotificationsTab() {
 
   async function sendTestTelegram() {
     try {
+      await persistForm()
       await notifApi.testTelegram()
       setTestMsg(m => ({ ...m, telegram: '✓ Test message sent' }))
     } catch (err: unknown) {
@@ -2170,6 +2177,7 @@ function NotificationsTab() {
 
   async function sendTestSlack() {
     try {
+      await persistForm()
       await notifApi.testSlack()
       setTestMsg(m => ({ ...m, slack: '✓ Test message sent' }))
     } catch (err: unknown) {
@@ -2180,6 +2188,7 @@ function NotificationsTab() {
   async function sendTestWeeklyDigest() {
     setTestMsg(m => ({ ...m, weekly: '… sending' }))
     try {
+      await persistForm()
       const r = await notifApi.testWeeklyDigest()
       const parts = Object.entries(r.results).map(([ch, status]) => `${ch}:${status}`).join('  ')
       setTestMsg(m => ({ ...m, weekly: `✓ ${parts}` }))
@@ -2190,6 +2199,7 @@ function NotificationsTab() {
 
   async function detectChatId() {
     try {
+      await persistForm()
       const result = await notifApi.detectChatId()
       setChatIds(result.chats)
     } catch (err: unknown) {
@@ -2210,7 +2220,7 @@ function NotificationsTab() {
         {form.email_enabled && (
           <div className="grid grid-cols-2 gap-3">
             <div><label className="label">SMTP Host</label><input className="input" value={form.smtp_host ?? ''} onChange={e => setForm(f => ({ ...f, smtp_host: e.target.value }))} /></div>
-            <div><label className="label">Port</label><input type="number" className="input" value={form.smtp_port ?? 587} onChange={e => setForm(f => ({ ...f, smtp_port: parseInt(e.target.value) }))} /></div>
+            <div><label className="label">Port</label><input type="number" className="input" value={form.smtp_port ?? 587} onChange={e => setForm(f => ({ ...f, smtp_port: parseInt(e.target.value) || 587 }))} /></div>
             <div><label className="label">Username</label><input className="input" value={form.smtp_username ?? ''} onChange={e => setForm(f => ({ ...f, smtp_username: e.target.value }))} /></div>
             <div><label className="label">Password</label><input type="password" className="input" value={form.smtp_password ?? ''} onChange={e => setForm(f => ({ ...f, smtp_password: e.target.value }))} placeholder="unchanged" /></div>
             <div><label className="label">From</label><input className="input" value={form.email_from ?? ''} onChange={e => setForm(f => ({ ...f, email_from: e.target.value }))} /></div>
@@ -2376,6 +2386,9 @@ function NotificationsTab() {
                     onChange={e => setForm(f => ({ ...f, notify_weekly_digest_telegram: e.target.checked }))}
                     className="w-4 h-4 accent-green" />
                 </td>
+                {/* No weekly-digest Slack toggle — empty placeholder keeps the 6-column
+                    layout aligned so Webhook lands under the Webhook header, not Slack. */}
+                <td className="py-2 px-3 text-center text-text-muted text-xs">—</td>
                 <td className="py-2 px-3 text-center">
                   <input type="checkbox" checked={form.notify_weekly_digest_webhook ?? true}
                     disabled={!form.webhook_enabled}
@@ -2841,21 +2854,26 @@ function AccountTab() {
   const [form, setForm] = useState({ current_password: '', new_password: '', confirm: '' })
   const [msg, setMsg] = useState('')
   const [error, setError] = useState('')
+  const [saving, setSaving] = useState(false)
 
   async function handleChangePassword(e: React.FormEvent) {
     e.preventDefault()
+    if (saving) return
     setMsg('')
     setError('')
     if (form.new_password !== form.confirm) {
       setError('New passwords do not match')
       return
     }
+    setSaving(true)
     try {
       await auth.changePassword(form.current_password, form.new_password)
       setMsg('Password changed successfully')
       setForm({ current_password: '', new_password: '', confirm: '' })
     } catch (err: unknown) {
       setError((err as Error).message)
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -2874,7 +2892,7 @@ function AccountTab() {
           <div><label className="label">Confirm New Password</label><input type="password" className="input" value={form.confirm} onChange={e => setForm(f => ({ ...f, confirm: e.target.value }))} /></div>
           {error && <p className="text-red text-sm">{error}</p>}
           {msg && <p className="text-green text-sm">{msg}</p>}
-          <button type="submit" className="btn-primary">Change Password</button>
+          <button type="submit" className="btn-primary" disabled={saving}>{saving ? 'Changing…' : 'Change Password'}</button>
         </form>
       </div>
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1023,12 +1023,40 @@ function describeCronField(val: string, singular: string, plural: string, names?
   return parts.join(', ')
 }
 
-function describeCron(expr: string): string | null {
+// Per-field cron ranges: minute, hour, day-of-month, month, day-of-week (0 or 7 = Sun).
+const CRON_RANGES: [number, number][] = [[0, 59], [0, 23], [1, 31], [1, 12], [0, 7]]
+
+function cronFieldValid(v: string, lo: number, hi: number): boolean {
+  if (v === '*') return true
+  if (v.startsWith('*/')) {
+    const step = v.slice(2)
+    const n = parseInt(step)
+    return String(n) === step && n >= 1 && n <= hi   // step must be >= 1 (rejects */0)
+  }
+  return v.split(',').every(part => {
+    if (part.includes('-')) {
+      const [a, b] = part.split('-')
+      const na = parseInt(a), nb = parseInt(b)
+      return String(na) === a && String(nb) === b && na >= lo && nb <= hi && na <= nb
+    }
+    const n = parseInt(part)
+    return String(n) === part && n >= lo && n <= hi
+  })
+}
+
+// Range-aware cron validity. The old regex accepted out-of-range values like "*/0",
+// "60 6 * * *", or "0 25 * * *" as valid, which let a bad cron be persisted and then
+// silently crash job registration server-side (taking the scheduler down until fixed).
+function isValidCron(expr: string): boolean {
   const parts = expr.trim().split(/\s+/)
-  if (parts.length !== 5) return null
+  if (parts.length !== 5) return false
+  return parts.every((p, i) => cronFieldValid(p, CRON_RANGES[i][0], CRON_RANGES[i][1]))
+}
+
+function describeCron(expr: string): string | null {
+  if (!isValidCron(expr)) return null
+  const parts = expr.trim().split(/\s+/)
   const [min, hour, dom, month, dow] = parts
-  const validPart = (v: string) => /^(\*|(\*\/\d+)|\d+(,\d+)*(-\d+)?)$/.test(v)
-  if (!parts.every(validPart)) return null
 
   const minuteDesc = describeCronField(min, 'minute', 'minutes')
   const hourDesc = describeCronField(hour, 'hour', 'hours')
@@ -1069,7 +1097,7 @@ function CronInput({ value, onChange }: { value: string; onChange: (v: string) =
         placeholder="0 6 * * *"
         spellCheck={false}
       />
-      {invalid && <p className="text-xs text-red">Invalid cron expression — must be 5 fields (min hour dom month dow)</p>}
+      {invalid && <p className="text-xs text-red">Invalid cron — need 5 fields in range (min 0-59, hour 0-23, day 1-31, month 1-12, weekday 0-7)</p>}
       {desc && <p className="text-xs text-green font-mono">{desc}</p>}
     </div>
   )
@@ -1079,17 +1107,30 @@ function ScheduleTab() {
   const [cfg, setCfg] = useState<ScheduleConfig | null>(null)
   const [form, setForm] = useState<Partial<ScheduleConfig>>({})
   const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     schedulerApi.status().then(c => { setCfg(c); setForm(c) })
   }, [])
 
+  const cronInvalid = !!form.check_cron && !isValidCron(form.check_cron)
+
   async function handleSave(e: React.FormEvent) {
     e.preventDefault()
-    const updated = await schedulerApi.update(form)
-    setCfg(updated)
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
+    if (cronInvalid) { setError('Fix the cron expression before saving.'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await schedulerApi.update(form)
+      setCfg(updated)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err: unknown) {
+      setError((err as Error).message || 'Save failed')
+    } finally {
+      setSaving(false)
+    }
   }
 
   if (!cfg) return <p className="text-text-muted text-sm">Loading…</p>
@@ -1188,8 +1229,9 @@ function ScheduleTab() {
         {/* Save button lives inside the last form section so it's clearly tied
             to the schedule above, not the unrelated Maintenance Windows section below. */}
         <div className="flex items-center justify-end gap-3 pt-3 mt-2 border-t border-border/30">
+          {error && <span className="text-xs text-red">{error}</span>}
           {saved && <span className="text-xs text-green">✓ Saved</span>}
-          <button type="submit" className="btn-primary text-sm">Save Schedule</button>
+          <button type="submit" className="btn-primary text-sm" disabled={saving || cronInvalid}>{saving ? 'Saving…' : 'Save Schedule'}</button>
         </div>
       </section>
     </form>
@@ -1814,17 +1856,30 @@ function PreferencesTab() {
   const [cfg, setCfg] = useState<ScheduleConfig | null>(null)
   const [form, setForm] = useState<Partial<ScheduleConfig>>({})
   const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     schedulerApi.status().then(c => { setCfg(c); setForm(c) })
   }, [])
 
+  const cronInvalid = !!form.auto_upgrade_enabled && !!form.auto_upgrade_cron && !isValidCron(form.auto_upgrade_cron)
+
   async function handleSave(e: React.FormEvent) {
     e.preventDefault()
-    const updated = await schedulerApi.update(form)
-    setCfg(updated)
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
+    if (cronInvalid) { setError('Fix the auto-upgrade cron expression before saving.'); return }
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await schedulerApi.update(form)
+      setCfg(updated)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err: unknown) {
+      setError((err as Error).message || 'Save failed')
+    } finally {
+      setSaving(false)
+    }
   }
 
   if (!cfg) return <p className="text-text-muted text-sm">Loading…</p>
@@ -1994,7 +2049,10 @@ function PreferencesTab() {
       </section>
 
       <DisplayPreferencesSection />
-      <button type="submit" className="btn-primary">{saved ? '✓ Saved' : 'Save Preferences'}</button>
+      <div className="flex items-center gap-3">
+        <button type="submit" className="btn-primary" disabled={saving || cronInvalid}>{saving ? 'Saving…' : saved ? '✓ Saved' : 'Save Preferences'}</button>
+        {error && <span className="text-xs text-red">{error}</span>}
+      </div>
     </form>
     </div>
   )
@@ -2066,6 +2124,8 @@ function NotificationsTab() {
   const [cfg, setCfg] = useState<NotificationConfig | null>(null)
   const [form, setForm] = useState<Partial<NotificationConfig>>({})
   const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const [testMsg, setTestMsg] = useState<Record<string, string>>({})
   const [chatIds, setChatIds] = useState<{ id: number; title: string }[]>([])
 
@@ -2075,11 +2135,19 @@ function NotificationsTab() {
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault()
-    const updated = await notifApi.updateConfig(form)
-    setCfg(updated)
-    setForm(updated)
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
+    setSaving(true)
+    setError(null)
+    try {
+      const updated = await notifApi.updateConfig(form)
+      setCfg(updated)
+      setForm(updated)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err: unknown) {
+      setError((err as Error).message || 'Save failed')
+    } finally {
+      setSaving(false)
+    }
   }
 
   async function sendTestEmail() {
@@ -2471,7 +2539,10 @@ function NotificationsTab() {
         </div>
       </section>
 
-      <button type="submit" className="btn-primary">{saved ? '✓ Saved' : 'Save Notifications'}</button>
+      <div className="flex items-center gap-3">
+        <button type="submit" className="btn-primary" disabled={saving}>{saving ? 'Saving…' : saved ? '✓ Saved' : 'Save Notifications'}</button>
+        {error && <span className="text-xs text-red">{error}</span>}
+      </div>
     </form>
   )
 }

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -305,10 +305,15 @@ function ApplyTemplateModal({ template, onClose }: { template: Template; onClose
   const [done, setDone] = useState(false)
   const [progress, setProgress] = useState<Record<number, ServerProgress>>({})
   const [filterSrv, setFilterSrv] = useState<number | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
     serversApi.list().then(s => setServerList(s.filter(x => x.is_enabled)))
   }, [])
+
+  // Close the apply stream if the modal unmounts mid-run (e.g. navigate away via
+  // the command palette) so the socket and its handlers don't leak.
+  useEffect(() => () => { wsRef.current?.close() }, [])
 
   function toggleServer(id: number) {
     setSelectedServers(prev => {
@@ -327,7 +332,7 @@ function ApplyTemplateModal({ template, onClose }: { template: Template; onClose
     ids.forEach(id => { initial[id] = { status: 'pending', lines: [] } })
     setProgress(initial)
 
-    createTemplateApplyWebSocket(template.id, ids, (msg) => {
+    wsRef.current = createTemplateApplyWebSocket(template.id, ids, (msg) => {
       const sid = msg.server_id as number
       if (!sid) return
       if (msg.type === 'output') {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -311,7 +311,7 @@ export interface AptCacheStats extends AptCacheServer {
   data_fetched_recent: string
   data_served_startup: string
   data_served_recent: string
-  daily: AptCacheDailyRow[]
+  daily?: AptCacheDailyRow[]   // absent when the server is unreachable (ok: false)
 }
 
 export interface NotificationLog {


### PR DESCRIPTION
Fixes the **40 verified frontend bugs** from the multi-agent audit in #61 (1 Critical, 7 High, 9 Medium, 23 Low). Each was adversarially verified against the code before fixing. `npm run build` (tsc + vite) passes after every commit.

Closes #61

## Highlights (the "things that don't work")
- **2FA login was impossible** — the API client flattened every 401 to "Session expired", so the 2FA challenge never surfaced. Now preserves the backend `detail`.
- **"Upgrade All" with a filter upgraded the whole fleet** — the modal now sends `server_ids` and the backend honors them (same fix applied to Autoremove-All and Rolling-Reboot).
- **Install modal vanished on completion** — result/terminal view now survives the socket close.
- **Apt Repos editor could save server A's repos onto server B** — ServerDetail is now keyed by route id, so switching servers fully remounts.
- **Silent save failures / invalid cron** — Schedule/Preferences/Notifications saves show errors; cron is range-validated and Save is disabled while invalid.

## What's in here
| Commit | Severity | Area |
|---|---|---|
| `0bdc92f` | Critical + High | 2FA login, WS close→1008 redirect, Compare diverged, install modal |
| `288db9c` | High | ServerDetail route keying, cron validation + save errors |
| `d2c514a` | High | Upgrade-All honors filter (FE + BE) |
| `553580f` | Medium | bulk-modal snapshot + filter + WS-failure state |
| `3f18cbb` | Medium | aptcache crash, NaN→NULL guards, tab deep-link, notif test, weekly-digest col, change-pw guard |
| `fcfa5b2` | Med/Low | command palette: fresh list, focus restore, aligned highlight |
| `870e468` | Low | ServerDetail WS/observer leaks, not-found state, stuck test, stats |
| `43f46e7` | Low | dashboard quirks, theme FOUC, slack badge, bell dot, DebInstall, Calendar, Templates WS, modal Escape |

## Backend changes
Minimal, backward-compatible, and only where a verified frontend bug required it:
- `ws_upgrade_all` / `ws_autoremove_all` accept an optional `server_ids` (omitted = all enabled, preserving prior behavior).

⚠️ These WebSocket paths were verified by code/syntax only — **a runtime smoke-test of Upgrade-All / Autoremove-All with an active filter is recommended** before merge.

## Out of scope
The 8 **backend correctness/security defects** listed at the bottom of #61 (CVE pipeline, shell-WS admin gate, Slack secret masking, dead `daily_summary_time`, etc.) are **not** in this PR — they came from a single-pass review and need a verification pass first.

## Testing
- ✅ `cd frontend && npm run build` (tsc type-check + vite build) — clean
- ✅ Backend Python syntax check on changed files
- ⬜ Manual/runtime verification (esp. 2FA login, Upgrade-All-with-filter, bulk-modal WS paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
