### PR TITLE
feat: roadmap quick-wins tier (6 features) — #62

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -210,6 +210,7 @@ async def init_db():
             "ALTER TABLE notification_config ADD COLUMN notify_weekly_digest_email BOOLEAN DEFAULT 1",
             "ALTER TABLE notification_config ADD COLUMN notify_weekly_digest_telegram BOOLEAN DEFAULT 1",
             "ALTER TABLE notification_config ADD COLUMN notify_weekly_digest_webhook BOOLEAN DEFAULT 1",
+            "ALTER TABLE notification_config ADD COLUMN notify_weekly_digest_slack BOOLEAN DEFAULT 1",
             # Rolling reboot orchestration (issue #56)
             "ALTER TABLE schedule_config ADD COLUMN reboot_batch_size INTEGER DEFAULT 3",
             "ALTER TABLE schedule_config ADD COLUMN reboot_batch_wait_minutes INTEGER DEFAULT 5",

--- a/backend/models.py
+++ b/backend/models.py
@@ -309,6 +309,7 @@ class NotificationConfig(Base):
     notify_weekly_digest_email: Mapped[bool] = mapped_column(Boolean, default=True)
     notify_weekly_digest_telegram: Mapped[bool] = mapped_column(Boolean, default=True)
     notify_weekly_digest_webhook: Mapped[bool] = mapped_column(Boolean, default=True)
+    notify_weekly_digest_slack: Mapped[bool] = mapped_column(Boolean, default=True)
 
 
 class ScheduleConfig(Base):

--- a/backend/notifier.py
+++ b/backend/notifier.py
@@ -1046,9 +1046,14 @@ async def compose_weekly_digest(db: AsyncSession) -> dict:
         except Exception:
             pkgs = []
         n = len(pkgs)
-        # We don't have per-package security flags in update_history, so we use
-        # an approximate name-based heuristic for the security counter.
+        # Prefer the persisted per-package is_security flag (recorded since the
+        # upgrade-history enrichment carries classification flags). Fall back to the
+        # old name-based heuristic only for legacy rows written before that change.
         for p in pkgs:
+            if isinstance(p, dict) and "is_security" in p:
+                if p.get("is_security"):
+                    security_pkgs_upgraded += 1
+                continue
             name = p.get("name") if isinstance(p, dict) else str(p)
             if isinstance(name, str) and any(tok in name for tok in ("-security", "linux-image", "openssl", "openssh")):
                 security_pkgs_upgraded += 1

--- a/backend/notifier.py
+++ b/backend/notifier.py
@@ -1537,7 +1537,7 @@ async def send_weekly_digest(cfg: NotificationConfig, db: AsyncSession) -> dict:
     payload = await compose_weekly_digest(db)
     subject = payload["subject"]
 
-    results: dict[str, str] = {"email": "skipped", "telegram": "skipped", "webhook": "skipped"}
+    results: dict[str, str] = {"email": "skipped", "telegram": "skipped", "webhook": "skipped", "slack": "skipped"}
 
     if cfg.email_enabled and getattr(cfg, "notify_weekly_digest_email", True):
         try:
@@ -1576,6 +1576,19 @@ async def send_weekly_digest(cfg: NotificationConfig, db: AsyncSession) -> dict:
         except Exception as exc:
             logger.error("Weekly digest webhook failed: %s", exc)
             results["webhook"] = f"error: {exc}"
+
+    if cfg.slack_enabled and getattr(cfg, "notify_weekly_digest_slack", True):
+        try:
+            await _send_slack(
+                cfg,
+                payload["headline"],
+                body=payload.get("telegram_body") or payload.get("text_body"),
+                event_type="weekly_digest",
+            )
+            results["slack"] = "sent"
+        except Exception as exc:
+            logger.error("Weekly digest slack failed: %s", exc)
+            results["slack"] = f"error: {exc}"
 
     return results
 

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -60,6 +60,8 @@ async def prometheus_metrics(authorization: str | None = Header(default=None)):
     g_kernel_age = Gauge("apt_ui_kernel_age_days", "Days since running kernel was installed", ["server"], registry=registry)
     g_disk = Gauge("apt_ui_disk_usage_percent", "Disk usage percentage", ["server", "mount"], registry=registry)
     g_held = Gauge("apt_ui_held_packages", "Number of held packages", ["server"], registry=registry)
+    g_sched_running = Gauge("apt_ui_scheduler_running", "Scheduler running (1=yes, 0=no)", registry=registry)
+    g_sched_unhealthy = Gauge("apt_ui_scheduler_unhealthy_jobs", "Enabled jobs not currently scheduled", registry=registry)
 
     async with AsyncSessionLocal() as db:
         servers_res = await db.execute(select(Server))
@@ -105,6 +107,14 @@ async def prometheus_metrics(authorization: str | None = Header(default=None)):
                 if stats.kernel_install_date:
                     age_days = (datetime.utcnow() - stats.kernel_install_date).days
                     g_kernel_age.labels(server=label).set(max(0, age_days))
+
+    try:
+        from backend.scheduler import scheduler_health
+        health = await scheduler_health()
+        g_sched_running.set(1 if health.get("running") else 0)
+        g_sched_unhealthy.set(len(health.get("issues", [])))
+    except Exception:
+        pass
 
     output = generate_latest(registry)
     return Response(content=output, media_type=CONTENT_TYPE_LATEST)

--- a/backend/routers/scheduler.py
+++ b/backend/routers/scheduler.py
@@ -83,6 +83,13 @@ async def get_status(
     return _to_out(cfg)
 
 
+@router.get("/health")
+async def get_scheduler_health(_: User = Depends(get_current_user)):
+    """Report whether config-enabled jobs are actually registered (self-heal banner)."""
+    from backend.scheduler import scheduler_health
+    return await scheduler_health()
+
+
 @router.put("/config", response_model=ScheduleConfigOut)
 async def update_config(
     body: ScheduleConfigUpdate,

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -77,6 +77,51 @@ async def fleet_overview(
     )
 
 
+@router.get("/stats/pending-updates")
+async def pending_updates(
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Aggregate every server's pending package list in one response, read from the
+    latest stored UpdateCheck (no live SSH). Replaces the dashboard modal's sequential
+    per-server /packages loop. New-dependency packages are excluded so the list count
+    matches packages_available."""
+    import json as _json
+
+    result = await db.execute(select(Server).where(Server.is_enabled == True))
+    servers = result.scalars().all()
+
+    out: list[dict] = []
+    for server in servers:
+        check_result = await db.execute(
+            select(UpdateCheck)
+            .where(UpdateCheck.server_id == server.id)
+            .order_by(UpdateCheck.checked_at.desc())
+            .limit(1)
+        )
+        check = check_result.scalar_one_or_none()
+        if check is None or check.status == "error" or (check.packages_available or 0) <= 0:
+            continue
+        packages: list[dict] = []
+        if check.packages_json:
+            try:
+                for p in _json.loads(check.packages_json):
+                    if p.get("is_new"):
+                        continue
+                    packages.append({
+                        "name": p.get("name"),
+                        "current_version": p.get("current_version", ""),
+                        "available_version": p.get("available_version", ""),
+                        "is_security": bool(p.get("is_security")),
+                        "is_phased": bool(p.get("is_phased")),
+                        "is_kernel": bool(p.get("is_kernel")),
+                    })
+            except Exception:
+                pass
+        out.append({"id": server.id, "packages": packages})
+    return {"servers": out}
+
+
 @router.get("/history")
 async def global_history(
     page: int = Query(default=1, ge=1),

--- a/backend/routers/upgrades.py
+++ b/backend/routers/upgrades.py
@@ -1061,12 +1061,21 @@ async def ws_template_apply(websocket: WebSocket, template_id: int):
         )
         servers = servers_result.scalars().all()
 
+        cfg_res = await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))
+        cfg = cfg_res.scalar_one_or_none()
+        concurrency = cfg.upgrade_concurrency if cfg else 5
+        actor = user.username
+        template_name = template.name
+
     pkg_str = " ".join(pkg_names)
+    semaphore = asyncio.Semaphore(max(1, concurrency))
+
+    from datetime import datetime
+    from backend.routers.maintenance import get_active_window_for_server
+    from backend.upgrade_manager import _get_lock
+    from backend.models import UpdateHistory
 
     async def _apply_to_server(server: Server):
-        sudo = "" if server.username == "root" else "sudo "
-        cmd = f"{sudo}DEBIAN_FRONTEND=noninteractive apt-get install -y {pkg_str}"
-
         async def send_fn(msg: dict):
             msg["server_id"] = server.id
             msg["server_name"] = server.name
@@ -1075,14 +1084,53 @@ async def ws_template_apply(websocket: WebSocket, template_id: int):
             except Exception:
                 pass
 
-        try:
-            from backend.ssh_manager import run_command_stream as _stream
-            await send_fn({"type": "status", "data": "connecting"})
-            result = await _stream(server, cmd, send_fn)
-            success = result.exit_code == 0
-            await send_fn({"type": "complete", "data": {"success": success, "packages": pkg_names}})
-        except Exception as exc:
-            await send_fn({"type": "error", "data": str(exc)})
+        async with semaphore:
+            # Respect maintenance windows — don't push a template install into a freeze.
+            async with AsyncSessionLocal() as wdb:
+                window = await get_active_window_for_server(wdb, server.id)
+            if window is not None:
+                await send_fn({"type": "error", "data": f"Skipped — in maintenance window '{window.name}'"})
+                return
+
+            sudo = "" if server.username == "root" else "sudo "
+            cmd = f"{sudo}DEBIAN_FRONTEND=noninteractive apt-get install -y {pkg_str}"
+
+            # Serialize with upgrades/other template applies on the same server.
+            async with _get_lock(server.id):
+                async with AsyncSessionLocal() as hdb:
+                    history = UpdateHistory(
+                        server_id=server.id, status="running",
+                        action=f"template:{template_name}", initiated_by=actor,
+                    )
+                    hdb.add(history)
+                    await hdb.commit()
+                    await hdb.refresh(history)
+                    history_id = history.id
+
+                success = False
+                log_output = ""
+                try:
+                    from backend.ssh_manager import run_command_stream as _stream
+                    await send_fn({"type": "status", "data": "connecting"})
+                    result = await _stream(server, cmd, send_fn)
+                    success = result.exit_code == 0
+                    log_output = getattr(result, "output", "") or ""
+                    await send_fn({"type": "complete", "data": {"success": success, "packages": pkg_names}})
+                except Exception as exc:
+                    await send_fn({"type": "error", "data": str(exc)})
+                    log_output = str(exc)
+                finally:
+                    try:
+                        async with AsyncSessionLocal() as hdb:
+                            h = await hdb.get(UpdateHistory, history_id)
+                            if h is not None:
+                                h.status = "success" if success else "error"
+                                h.completed_at = datetime.utcnow()
+                                h.packages_upgraded = json.dumps([{"name": n} for n in pkg_names]) if success else None
+                                h.log_output = log_output[:1_000_000] if log_output else None
+                                await hdb.commit()
+                    except Exception:
+                        pass
 
     try:
         await asyncio.gather(*[_apply_to_server(s) for s in servers])

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -398,39 +398,50 @@ async def configure_jobs():
 
     _remove_jobs()
 
+    # Each conditional job is registered independently: a bad cron on one must not
+    # prevent the others (or the unconditional jobs below) from being scheduled.
     if cfg and cfg.check_enabled:
-        _scheduler.add_job(
-            _job_check_all,
-            CronTrigger.from_crontab(cfg.check_cron, timezone=TZ),
-            id="check_all",
-            replace_existing=True,
-            misfire_grace_time=300,
-        )
-        logger.info("Scheduled check_all: %s (%s)", cfg.check_cron, TZ)
+        try:
+            _scheduler.add_job(
+                _job_check_all,
+                CronTrigger.from_crontab(cfg.check_cron, timezone=TZ),
+                id="check_all",
+                replace_existing=True,
+                misfire_grace_time=300,
+            )
+            logger.info("Scheduled check_all: %s (%s)", cfg.check_cron, TZ)
+        except Exception as exc:
+            logger.error("Failed to schedule check_all (cron=%r): %s", cfg.check_cron, exc)
 
     if cfg and cfg.auto_upgrade_enabled and cfg.auto_upgrade_cron:
-        _scheduler.add_job(
-            _job_auto_upgrade,
-            CronTrigger.from_crontab(cfg.auto_upgrade_cron, timezone=TZ),
-            id="auto_upgrade",
-            replace_existing=True,
-            misfire_grace_time=300,
-        )
-        logger.info("Scheduled auto_upgrade: %s (%s)", cfg.auto_upgrade_cron, TZ)
+        try:
+            _scheduler.add_job(
+                _job_auto_upgrade,
+                CronTrigger.from_crontab(cfg.auto_upgrade_cron, timezone=TZ),
+                id="auto_upgrade",
+                replace_existing=True,
+                misfire_grace_time=300,
+            )
+            logger.info("Scheduled auto_upgrade: %s (%s)", cfg.auto_upgrade_cron, TZ)
+        except Exception as exc:
+            logger.error("Failed to schedule auto_upgrade (cron=%r): %s", cfg.auto_upgrade_cron, exc)
 
     # Weekly digest (issue #58) — separate cron from daily_summary
     if cfg and cfg.weekly_digest_enabled:
-        dow = max(0, min(6, int(cfg.weekly_digest_day_of_week or 0)))
-        hour = max(0, min(23, int(cfg.weekly_digest_hour or 9)))
-        minute = max(0, min(59, int(cfg.weekly_digest_minute or 0)))
-        _scheduler.add_job(
-            _job_weekly_digest,
-            CronTrigger(day_of_week=dow, hour=hour, minute=minute, timezone=TZ),
-            id="weekly_digest",
-            replace_existing=True,
-            misfire_grace_time=600,
-        )
-        logger.info("Scheduled weekly_digest: dow=%d %02d:%02d (%s)", dow, hour, minute, TZ)
+        try:
+            dow = max(0, min(6, int(cfg.weekly_digest_day_of_week or 0)))
+            hour = max(0, min(23, int(cfg.weekly_digest_hour or 9)))
+            minute = max(0, min(59, int(cfg.weekly_digest_minute or 0)))
+            _scheduler.add_job(
+                _job_weekly_digest,
+                CronTrigger(day_of_week=dow, hour=hour, minute=minute, timezone=TZ),
+                id="weekly_digest",
+                replace_existing=True,
+                misfire_grace_time=600,
+            )
+            logger.info("Scheduled weekly_digest: dow=%d %02d:%02d (%s)", dow, hour, minute, TZ)
+        except Exception as exc:
+            logger.error("Failed to schedule weekly_digest: %s", exc)
 
     # Log purge always runs daily at 03:00
     _scheduler.add_job(
@@ -463,6 +474,45 @@ def _remove_jobs():
         job = _scheduler.get_job(job_id)
         if job:
             job.remove()
+
+
+async def scheduler_health() -> dict:
+    """Compare config-enabled jobs against what's actually registered in APScheduler.
+
+    Surfaces drift where a job is enabled in settings but isn't scheduled (e.g. a cron
+    that APScheduler rejected), so the UI can warn instead of silently doing nothing.
+    """
+    from backend.database import AsyncSessionLocal
+    from backend.models import ScheduleConfig
+    from sqlalchemy import select
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))
+        cfg = result.scalar_one_or_none()
+
+    expected: list[tuple[str, str]] = []
+    if cfg and cfg.check_enabled:
+        expected.append(("check_all", "Scheduled update check"))
+    if cfg and cfg.auto_upgrade_enabled and cfg.auto_upgrade_cron:
+        expected.append(("auto_upgrade", "Auto-upgrade"))
+    if cfg and cfg.weekly_digest_enabled:
+        expected.append(("weekly_digest", "Weekly digest"))
+
+    issues: list[dict] = []
+    for job_id, label in expected:
+        job = _scheduler.get_job(job_id)
+        if job is None or job.next_run_time is None:
+            issues.append({
+                "job": job_id,
+                "label": label,
+                "reason": "enabled in settings but not scheduled — check the cron expression",
+            })
+
+    return {
+        "running": _scheduler.running,
+        "healthy": _scheduler.running and not issues,
+        "issues": issues,
+    }
 
 
 async def start_scheduler():

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -401,6 +401,7 @@ class NotificationConfigOut(BaseModel):
     notify_weekly_digest_email: bool = True
     notify_weekly_digest_telegram: bool = True
     notify_weekly_digest_webhook: bool = True
+    notify_weekly_digest_slack: bool = True
 
     model_config = {"from_attributes": True}
 
@@ -454,6 +455,7 @@ class NotificationConfigUpdate(BaseModel):
     notify_weekly_digest_email: Optional[bool] = None
     notify_weekly_digest_telegram: Optional[bool] = None
     notify_weekly_digest_webhook: Optional[bool] = None
+    notify_weekly_digest_slack: Optional[bool] = None
 
 
 class NotificationLogOut(BaseModel):

--- a/backend/upgrade_manager.py
+++ b/backend/upgrade_manager.py
@@ -590,6 +590,11 @@ async def _enrich_packages_with_versions(
                 version_map[p["name"]] = {
                     "from_version": p.get("current_version", ""),
                     "to_version": p.get("available_version", ""),
+                    # Carry the classification flags so the digest and Stats series can
+                    # use ground truth instead of re-deriving from package names.
+                    "is_security": bool(p.get("is_security")),
+                    "is_kernel": bool(p.get("is_kernel")),
+                    "is_new": bool(p.get("is_new")),
                 }
     except Exception:
         pass
@@ -600,5 +605,8 @@ async def _enrich_packages_with_versions(
         if name in version_map:
             entry["from_version"] = version_map[name]["from_version"]
             entry["to_version"] = version_map[name]["to_version"]
+            entry["is_security"] = version_map[name]["is_security"]
+            entry["is_kernel"] = version_map[name]["is_kernel"]
+            entry["is_new"] = version_map[name]["is_new"]
         enriched.append(entry)
     return enriched

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -290,8 +290,19 @@ export const templates = {
 // Stats
 // ---------------------------------------------------------------------------
 
+export interface PendingUpdatePkg {
+  name: string
+  current_version: string
+  available_version: string
+  is_security: boolean
+  is_phased: boolean
+  is_kernel?: boolean
+}
+
 export const stats = {
   overview: () => get<FleetOverview>('/api/stats/overview'),
+  pendingUpdates: () =>
+    get<{ servers: { id: number; packages: PendingUpdatePkg[] }[] }>('/api/stats/pending-updates'),
   globalHistory: (page = 1, serverId?: number, status?: string) => {
     const params = new URLSearchParams({ page: String(page) })
     if (serverId !== undefined) params.set('server_id', String(serverId))

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -304,9 +304,16 @@ export const stats = {
 // Scheduler
 // ---------------------------------------------------------------------------
 
+export interface SchedulerHealth {
+  running: boolean
+  healthy: boolean
+  issues: { job: string; label: string; reason: string }[]
+}
+
 export const scheduler = {
   status: () => get<ScheduleConfig>('/api/scheduler/status'),
   update: (data: Partial<ScheduleConfig>) => put<ScheduleConfig>('/api/scheduler/config', data),
+  health: () => get<SchedulerHealth>('/api/scheduler/health'),
 }
 
 export interface MaintenanceWindow {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -98,6 +98,9 @@ export default function Dashboard() {
     () => (_initialUrl.get('sort') as any) || (localStorage.getItem('dashboard:sortBy') as 'name' | 'updates' | 'status' | 'group') || 'status'
   )
   const [groupView, setGroupView] = useState(_initialUrl.get('view') === 'group')
+  const [density, setDensity] = useState<'comfortable' | 'compact'>(
+    () => (localStorage.getItem('dashboard:density') as 'comfortable' | 'compact') || 'comfortable'
+  )
   const [statusFilter, setStatusFilter] = useState<string | null>(_initialUrl.get('status') || null)
   const [checking, setChecking] = useState<Set<number>>(new Set())
   const { addJob, updateJob } = useJobStore()
@@ -515,6 +518,13 @@ export default function Dashboard() {
         >
           ⊞ Group
         </button>
+        <button
+          onClick={() => setDensity(d => { const n = d === 'compact' ? 'comfortable' : 'compact'; localStorage.setItem('dashboard:density', n); return n })}
+          className={`btn-secondary text-xs ${density === 'compact' ? 'bg-surface-2' : ''}`}
+          title="Toggle compact list view"
+        >
+          {density === 'compact' ? '▭ Cards' : '≣ List'}
+        </button>
         <div className="relative group/check">
           <button onClick={handleRefreshAll} disabled={checkingAll} className="btn-secondary text-xs">
             {checkingAll && checkingMode === 'refresh'
@@ -609,17 +619,20 @@ export default function Dashboard() {
                   <span className="text-sm font-mono text-text-muted">{groupName ?? 'Ungrouped'}</span>
                   <span className="text-xs text-text-muted">({groupServers.length})</span>
                 </div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                  {groupServers.map(s => (
-                    <ServerCard
-                      key={s.id}
-                      server={s}
-                      checking={checking.has(s.id)}
-                      onCheck={() => handleCheck(s.id)}
-                      onToggleEnabled={(e) => handleToggleEnabled(s, e)}
-                      reachable={reachability[s.id]}
-                    />
-                  ))}
+                <div className={density === 'compact' ? 'flex flex-col gap-1.5' : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3'}>
+                  {groupServers.map(s => {
+                    const Item = density === 'compact' ? ServerRow : ServerCard
+                    return (
+                      <Item
+                        key={s.id}
+                        server={s}
+                        checking={checking.has(s.id)}
+                        onCheck={() => handleCheck(s.id)}
+                        onToggleEnabled={(e) => handleToggleEnabled(s, e)}
+                        reachable={reachability[s.id]}
+                      />
+                    )
+                  })}
                 </div>
               </div>
             )
@@ -627,17 +640,20 @@ export default function Dashboard() {
           })()}
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-          {filtered.map(s => (
-            <ServerCard
-              key={s.id}
-              server={s}
-              checking={checking.has(s.id)}
-              onCheck={() => handleCheck(s.id)}
-              onToggleEnabled={(e) => handleToggleEnabled(s, e)}
-              reachable={reachability[s.id]}
-            />
-          ))}
+        <div className={density === 'compact' ? 'flex flex-col gap-1.5' : 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3'}>
+          {filtered.map(s => {
+            const Item = density === 'compact' ? ServerRow : ServerCard
+            return (
+              <Item
+                key={s.id}
+                server={s}
+                checking={checking.has(s.id)}
+                onCheck={() => handleCheck(s.id)}
+                onToggleEnabled={(e) => handleToggleEnabled(s, e)}
+                reachable={reachability[s.id]}
+              />
+            )
+          })}
           {!initialLoaded && (
             <div className="col-span-full py-12 text-center text-text-muted text-sm">Loading…</div>
           )}
@@ -969,6 +985,46 @@ function RebootButton({ serverId, serverName, className = '' }: {
 // ---------------------------------------------------------------------------
 // Server card
 // ---------------------------------------------------------------------------
+// Compact single-row representation used by the dashboard "List" density mode.
+function ServerRow({ server: s, checking, onCheck, reachable }: {
+  server: Server
+  checking: boolean
+  onCheck: () => void
+  onToggleEnabled: (e: React.MouseEvent) => void
+  reachable?: boolean | null
+}) {
+  const navigate = useNavigate()
+  const status = checking ? 'checking' : serverStatus(s)
+  const c = s.latest_check
+  const primaryGroupColor = (s.groups ?? [])[0]?.color || s.group_color || null
+  return (
+    <div
+      className={`card px-3 py-1.5 flex items-center gap-3 cursor-pointer hover:border-text-muted transition-colors ${!s.is_enabled ? 'opacity-50' : s.is_reachable === false ? 'opacity-60' : ''}`}
+      style={primaryGroupColor ? { borderLeft: `3px solid ${s.is_reachable === false ? '#ef4444' : primaryGroupColor}66` } : (s.is_reachable === false ? { borderLeft: '3px solid #ef444466' } : undefined)}
+      onClick={() => navigate(`/servers/${s.id}`)}
+    >
+      <StatusDot status={status} />
+      {reachable === false && <span title="SSH unreachable" className="w-1.5 h-1.5 rounded-full bg-red inline-block shrink-0 -ml-1.5" />}
+      <div className="min-w-0 flex-1 flex items-center gap-2">
+        <span className="font-mono text-sm text-text-primary truncate">{s.name}</span>
+        <span className="text-xs text-text-muted font-mono truncate hidden sm:inline">{s.hostname}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs font-mono shrink-0">
+        {c?.status === 'error' && <span className="text-red">error</span>}
+        {c && c.status !== 'error' && c.packages_available > 0 && (
+          <span className="text-amber">{c.packages_available}↑{c.security_packages > 0 && <span className="text-red"> · {c.security_packages} sec</span>}</span>
+        )}
+        {c && c.status !== 'error' && c.packages_available === 0 && <span className="text-green">up to date</span>}
+        {!c && <span className="text-text-muted">unknown</span>}
+        {c?.reboot_required && <span title="reboot required" className="text-amber">↻</span>}
+      </div>
+      <div className="flex items-center gap-1 shrink-0" onClick={e => e.stopPropagation()}>
+        <button onClick={onCheck} disabled={checking} className="btn-secondary text-xs py-0.5 px-2 disabled:opacity-50">{checking ? '…' : 'Check'}</button>
+      </div>
+    </div>
+  )
+}
+
 function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable }: {
   server: Server
   checking: boolean

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { Link, useNavigate } from 'react-router-dom'
-import { servers as serversApi, groups as groupsApi, stats as statsApi, aptcache as aptcacheApi } from '@/api/client'
+import { servers as serversApi, groups as groupsApi, stats as statsApi, aptcache as aptcacheApi, type PendingUpdatePkg } from '@/api/client'
 import type { Server, ServerGroup, FleetOverview, ServerStatus, Tag, AptCacheStats, AptCacheDailyRow, PackageInfo } from '@/types'
 import { usePolling } from '@/hooks/usePolling'
 import { useAuthStore } from '@/hooks/useAuth'
@@ -711,27 +711,61 @@ function UpdatesSummaryModal({ servers, onClose }: { servers: Server[]; onClose:
   const totalPkgs = servers.reduce((sum, s) => sum + (s.latest_check?.packages_available ?? 0), 0)
   const totalSec = servers.reduce((sum, s) => sum + (s.latest_check?.security_packages ?? 0), 0)
 
-  // Fetch packages for each server as the modal opens
-  const [pkgMap, setPkgMap] = useState<Record<number, PackageInfo[] | null>>({})
+  // One aggregate call (cached UpdateCheck data) instead of a sequential per-server loop.
+  const [pkgMap, setPkgMap] = useState<Record<number, PendingUpdatePkg[]> | null>(null)
+  const [loadError, setLoadError] = useState(false)
+  const [filter, setFilter] = useState('')
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     let cancelled = false
-    async function fetchAll() {
-      for (const s of sorted) {
-        try {
-          const res = await serversApi.packages(s.id)
-          if (!cancelled) {
-            setPkgMap(prev => ({ ...prev, [s.id]: res.packages }))
-          }
-        } catch {
-          if (!cancelled) setPkgMap(prev => ({ ...prev, [s.id]: null }))
-        }
+    statsApi.pendingUpdates()
+      .then(res => {
+        if (cancelled) return
+        const map: Record<number, PendingUpdatePkg[]> = {}
+        for (const row of res.servers) map[row.id] = row.packages
+        setPkgMap(map)
+      })
+      .catch(() => { if (!cancelled) setLoadError(true) })
+    return () => { cancelled = true }
+  }, [])
+
+  const q = filter.trim().toLowerCase()
+  const matchPkg = (p: PendingUpdatePkg) => !q || p.name.toLowerCase().includes(q)
+
+  // Flatten to rows for export (respecting the active filter).
+  function exportRows(): { server: string; hostname: string; pkg: string; from: string; to: string; security: boolean }[] {
+    if (!pkgMap) return []
+    const rows: { server: string; hostname: string; pkg: string; from: string; to: string; security: boolean }[] = []
+    for (const s of sorted) {
+      for (const p of (pkgMap[s.id] ?? []).filter(matchPkg)) {
+        rows.push({ server: s.name, hostname: s.hostname, pkg: p.name, from: p.current_version, to: p.available_version, security: p.is_security })
       }
     }
-    fetchAll()
-    return () => { cancelled = true }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    return rows
+  }
+
+  function downloadCsv() {
+    const rows = exportRows()
+    const esc = (v: string) => `"${String(v ?? '').replace(/"/g, '""')}"`
+    const csv = ['server,hostname,package,current_version,available_version,security',
+      ...rows.map(r => [r.server, r.hostname, r.pkg, r.from, r.to, r.security ? 'yes' : 'no'].map(esc).join(','))].join('\n')
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'pending-updates.csv'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function copyList() {
+    const rows = exportRows()
+    const text = rows.map(r => `${r.server}\t${r.pkg}\t${r.from} -> ${r.to}${r.security ? '\t[security]' : ''}`).join('\n')
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(() => { setCopied(true); setTimeout(() => setCopied(false), 1500) }).catch(() => {})
+    }
+  }
 
   // Close on Escape
   useEffect(() => {
@@ -759,14 +793,36 @@ function UpdatesSummaryModal({ servers, onClose }: { servers: Server[]; onClose:
           <button onClick={onClose} className="text-text-muted hover:text-text-primary transition-colors text-lg leading-none">×</button>
         </div>
 
+        {/* Toolbar: filter + export */}
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-border shrink-0">
+          <input
+            type="text"
+            placeholder="Filter packages…"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            className="input text-xs px-2 py-1 w-48"
+          />
+          <div className="ml-auto flex items-center gap-2">
+            <button onClick={copyList} disabled={!pkgMap} className="btn-secondary text-xs py-1 disabled:opacity-50">
+              {copied ? 'Copied ✓' : 'Copy'}
+            </button>
+            <button onClick={downloadCsv} disabled={!pkgMap} className="btn-secondary text-xs py-1 disabled:opacity-50">Export CSV</button>
+          </div>
+        </div>
+
         {/* Scrollable body */}
         <div className="overflow-y-auto flex-1 divide-y divide-border/40">
+          {loadError && (
+            <div className="px-4 py-6 text-center text-xs text-red font-mono">Failed to load package lists.</div>
+          )}
           {sorted.map(s => {
             const c = s.latest_check!
-            const pkgs = pkgMap[s.id]
-            const loading = !(s.id in pkgMap)
-            const secPkgs = pkgs?.filter(p => p.is_security).sort((a, b) => a.name.localeCompare(b.name)) ?? []
-            const regPkgs = pkgs?.filter(p => !p.is_security).sort((a, b) => a.name.localeCompare(b.name)) ?? []
+            const pkgs = pkgMap?.[s.id]
+            const loading = pkgMap === null && !loadError
+            const secPkgs = (pkgs ?? []).filter(p => p.is_security && matchPkg(p)).sort((a, b) => a.name.localeCompare(b.name))
+            const regPkgs = (pkgs ?? []).filter(p => !p.is_security && matchPkg(p)).sort((a, b) => a.name.localeCompare(b.name))
+            // When filtering, hide servers with no matching packages.
+            if (q && !loading && secPkgs.length === 0 && regPkgs.length === 0) return null
 
             return (
               <div key={s.id} className="px-4 py-3 space-y-2">
@@ -807,13 +863,10 @@ function UpdatesSummaryModal({ servers, onClose }: { servers: Server[]; onClose:
                 {loading && (
                   <div className="text-xs text-text-muted font-mono animate-pulse">Loading packages…</div>
                 )}
-                {pkgs === null && (
-                  <div className="text-xs text-red font-mono">Failed to load package list</div>
-                )}
-                {pkgs && pkgs.length === 0 && (
+                {!loading && pkgs && pkgs.length === 0 && (
                   <div className="text-xs text-text-muted font-mono">No package details available</div>
                 )}
-                {pkgs && pkgs.length > 0 && (
+                {!loading && (secPkgs.length > 0 || regPkgs.length > 0) && (
                   <div className="space-y-0.5">
                     {secPkgs.map(p => (
                       <div key={p.name} className="flex items-baseline gap-2 text-xs font-mono py-0.5 px-2 rounded bg-red/5">

--- a/frontend/src/pages/ServerDetail.tsx
+++ b/frontend/src/pages/ServerDetail.tsx
@@ -1859,7 +1859,7 @@ function StatsTab({ serverId }: { serverId: number }) {
         .map(h => ({
           date: new Date(h.started_at).toLocaleDateString(),
           packages: h.packages_upgraded?.length ?? 0,
-          security: 0,
+          security: (h.packages_upgraded ?? []).filter(p => p.is_security).length,
         }))
       setData(points)
     })
@@ -1870,16 +1870,23 @@ function StatsTab({ serverId }: { serverId: number }) {
   return (
     <div className="space-y-4">
       <div className="card p-4">
-        <h3 className="text-xs text-text-muted uppercase tracking-wide mb-4">Packages upgraded per run (recent)</h3>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-xs text-text-muted uppercase tracking-wide">Packages upgraded per run (recent)</h3>
+          <div className="flex items-center gap-3 text-[10px] text-text-muted font-mono">
+            <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full inline-block" style={{ background: '#22c55e' }} />total</span>
+            <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full inline-block" style={{ background: '#ef4444' }} />security</span>
+          </div>
+        </div>
         <ResponsiveContainer width="100%" height={200}>
           <LineChart data={data}>
             <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
-            <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} />
+            <YAxis tick={{ fill: '#6b7280', fontSize: 11 }} allowDecimals={false} />
             <Tooltip
               contentStyle={{ background: '#1a1d27', border: '1px solid #2e3347', borderRadius: '4px', fontSize: '12px' }}
               labelStyle={{ color: '#e5e7eb' }}
             />
-            <Line type="monotone" dataKey="packages" stroke="#22c55e" dot={data.length <= 2} strokeWidth={1.5} />
+            <Line type="monotone" dataKey="packages" name="total" stroke="#22c55e" dot={data.length <= 2} strokeWidth={1.5} />
+            <Line type="monotone" dataKey="security" name="security" stroke="#ef4444" dot={data.length <= 2} strokeWidth={1.5} />
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -2380,9 +2380,12 @@ function NotificationsTab() {
                     onChange={e => setForm(f => ({ ...f, notify_weekly_digest_telegram: e.target.checked }))}
                     className="w-4 h-4 accent-green" />
                 </td>
-                {/* No weekly-digest Slack toggle — empty placeholder keeps the 6-column
-                    layout aligned so Webhook lands under the Webhook header, not Slack. */}
-                <td className="py-2 px-3 text-center text-text-muted text-xs">—</td>
+                <td className="py-2 px-3 text-center">
+                  <input type="checkbox" checked={form.notify_weekly_digest_slack ?? true}
+                    disabled={!form.slack_enabled}
+                    onChange={e => setForm(f => ({ ...f, notify_weekly_digest_slack: e.target.checked }))}
+                    className="w-4 h-4 accent-green disabled:opacity-30" />
+                </td>
                 <td className="py-2 px-3 text-center">
                   <input type="checkbox" checked={form.notify_weekly_digest_webhook ?? true}
                     disabled={!form.webhook_enabled}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1105,9 +1105,13 @@ function ScheduleTab() {
   const [saved, setSaved] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [health, setHealth] = useState<import('@/api/client').SchedulerHealth | null>(null)
+
+  const refreshHealth = () => { schedulerApi.health().then(setHealth).catch(() => {}) }
 
   useEffect(() => {
     schedulerApi.status().then(c => { setCfg(c); setForm(c) })
+    refreshHealth()
   }, [])
 
   const cronInvalid = !!form.check_cron && !isValidCron(form.check_cron)
@@ -1122,6 +1126,7 @@ function ScheduleTab() {
       setCfg(updated)
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
+      refreshHealth()   // reconcile the banner after the scheduler reconfigures
     } catch (err: unknown) {
       setError((err as Error).message || 'Save failed')
     } finally {
@@ -1133,6 +1138,18 @@ function ScheduleTab() {
 
   return (
     <form onSubmit={handleSave} className="space-y-6 max-w-xl">
+      {health && !health.healthy && (
+        <div className="rounded border border-red/40 bg-red/5 px-3 py-2 text-xs space-y-1">
+          <p className="font-medium text-red">
+            ⚠ {!health.running ? 'The scheduler is not running.' : 'Some enabled jobs are not scheduled.'}
+          </p>
+          {health.issues.map(i => (
+            <p key={i.job} className="text-text-muted">
+              <span className="font-mono text-text-primary">{i.label}</span> — {i.reason}
+            </p>
+          ))}
+        </div>
+      )}
       <section className="card p-4 space-y-4">
         <h2 className="text-sm font-medium text-text-primary">Update Check Schedule</h2>
         <div className="flex items-center gap-3">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -256,6 +256,7 @@ export interface NotificationConfig {
   notify_weekly_digest_email: boolean
   notify_weekly_digest_telegram: boolean
   notify_weekly_digest_webhook: boolean
+  notify_weekly_digest_slack: boolean
 }
 
 export interface TemplatePackage {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -159,7 +159,7 @@ export interface UpdateHistory {
   status: string
   action: string
   phased_updates: boolean
-  packages_upgraded: Array<{ name: string; from_version: string; to_version: string }> | null
+  packages_upgraded: Array<{ name: string; from_version: string; to_version: string; is_security?: boolean; is_kernel?: boolean; is_new?: boolean }> | null
   log_output: string | null
   initiated_by: string
 }


### PR DESCRIPTION
First batch of the enhancement roadmap (#62): the **Quick wins tier (6/6)**. These are the highest-leverage, contained items, and several are prerequisites for later tiers (per the roadmap's sequencing note). One feature per commit.

Part of #62 (quick-wins tier). Later tiers (high-impact bets, ambitious, novel) will follow in their own PRs.

## What's in here

1. **Persist per-package security/kernel/new flags into upgrade history** (`be05d7f`)
   Carries `is_security`/`is_kernel`/`is_new` from the latest check into each `UpdateHistory.packages_upgraded` entry (additive JSON, no schema change). Unblocks the digest's security counter (now uses the persisted flag, name-heuristic only as a legacy fallback) and the ServerDetail Stats chart (now plots a real `security` series instead of hardcoded `0`). *Prerequisite for trends/digest.*

2. **Slack as a first-class weekly-digest channel** (`fa58e33`)
   New `notify_weekly_digest_slack` column (model + migration + schemas); `send_weekly_digest` delivers to Slack; the Settings weekly-digest Slack cell is now a real toggle.

3. **Template apply: concurrency cap + window/lock respect + history** (`ae4000f`)
   `ws_template_apply` now bounds parallelism with a semaphore sized from `upgrade_concurrency`, skips servers in an active maintenance window, serializes per-server via the shared lock, and records an `UpdateHistory` row per server.

4. **Scheduler self-heal + health surface + banner** (`9449fe2`)
   `configure_jobs` registers each job independently (one bad cron can't drop the others); new `scheduler_health()` + `GET /api/scheduler/health`; Settings > Schedule shows a banner when an enabled job isn't actually scheduled; `/metrics` gains `apt_ui_scheduler_running` and `apt_ui_scheduler_unhealthy_jobs`.

5. **Fleet pending-updates aggregate endpoint + modal filter/export** (`3322ac1`)
   New `GET /api/stats/pending-updates` returns every server's pending list in one response from stored check data (no live SSH, no per-server loop). The dashboard modal uses it, adds a package-name filter, and Copy / Export-CSV.

6. **Dashboard compact list (density) view toggle** (`3fc15ad`)
   List/Cards toggle (persisted to `dashboard:density`) rendering servers as compact rows — much easier to scan on large fleets. Works in flat and grouped views.

## DB migrations
- `notification_config.notify_weekly_digest_slack` (added to the `init_db()` migrations list per project convention).

## Testing
- ✅ `make ci` (Python syntax + import check + frontend `tsc` + vite build) — all green.
- ⬜ Runtime verification recommended for: weekly-digest Slack delivery, template-apply window/lock behavior, the scheduler-health banner, and the pending-updates modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
