### PR TITLE
feat: roadmap high-impact tier (part 1: toast/confirm, N+1, trends) — #62

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -405,3 +405,20 @@ class TemplatePackage(Base):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     template: Mapped["Template"] = relationship("Template", back_populates="packages")
+
+
+class FleetSnapshot(Base):
+    """Point-in-time fleet aggregate, written after each scheduled check-all so the
+    dashboard can plot trends (the donut is point-in-time and raw rows get purged)."""
+    __tablename__ = "fleet_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    recorded_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), index=True)
+    total_servers: Mapped[int] = mapped_column(Integer, default=0)
+    up_to_date: Mapped[int] = mapped_column(Integer, default=0)
+    updates_available: Mapped[int] = mapped_column(Integer, default=0)
+    security_servers: Mapped[int] = mapped_column(Integer, default=0)
+    errors: Mapped[int] = mapped_column(Integer, default=0)
+    reboot_required: Mapped[int] = mapped_column(Integer, default=0)
+    pending_packages_total: Mapped[int] = mapped_column(Integer, default=0)
+    security_packages_total: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/query_helpers.py
+++ b/backend/query_helpers.py
@@ -51,3 +51,34 @@ async def latest_stats_by_server(db: AsyncSession) -> dict[int, ServerStats]:
     for st in result.scalars().all():
         out[st.server_id] = st
     return out
+
+
+async def record_fleet_snapshot(db: AsyncSession) -> None:
+    """Compute and persist a point-in-time fleet aggregate (for trend charts)."""
+    from backend.models import Server, FleetSnapshot
+
+    servers = (await db.execute(select(Server).where(Server.is_enabled == True))).scalars().all()
+    checks = await latest_checks_by_server(db)
+    up = ua = sec = err = reboot = pend = secpk = 0
+    for s in servers:
+        chk = checks.get(s.id)
+        if chk is None:
+            continue
+        if chk.status == "error":
+            err += 1
+        elif (chk.packages_available or 0) == 0:
+            up += 1
+        else:
+            ua += 1
+            if (chk.security_packages or 0) > 0:
+                sec += 1
+        if chk.reboot_required:
+            reboot += 1
+        pend += (chk.packages_available or 0)
+        secpk += (chk.security_packages or 0)
+    db.add(FleetSnapshot(
+        total_servers=len(servers), up_to_date=up, updates_available=ua,
+        security_servers=sec, errors=err, reboot_required=reboot,
+        pending_packages_total=pend, security_packages_total=secpk,
+    ))
+    await db.commit()

--- a/backend/query_helpers.py
+++ b/backend/query_helpers.py
@@ -1,0 +1,53 @@
+"""Shared queries for the per-server "latest row" lookups.
+
+Several hot endpoints (/stats/overview, /status.json, /metrics, list_servers, reports)
+previously looped a separate "latest UpdateCheck/ServerStats for this server" query per
+server — an N+1 that ran on every 30s dashboard poll, every metrics scrape, and every
+unauthenticated status hit. These helpers fetch all of them in a single query each.
+"""
+from sqlalchemy import select, func, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models import UpdateCheck, ServerStats
+
+
+async def latest_checks_by_server(db: AsyncSession) -> dict[int, UpdateCheck]:
+    """Return {server_id: latest UpdateCheck} in one query (was one query per server)."""
+    subq = (
+        select(
+            UpdateCheck.server_id.label("sid"),
+            func.max(UpdateCheck.checked_at).label("mx"),
+        )
+        .group_by(UpdateCheck.server_id)
+        .subquery()
+    )
+    stmt = select(UpdateCheck).join(
+        subq,
+        and_(UpdateCheck.server_id == subq.c.sid, UpdateCheck.checked_at == subq.c.mx),
+    )
+    result = await db.execute(stmt)
+    out: dict[int, UpdateCheck] = {}
+    for chk in result.scalars().all():
+        out[chk.server_id] = chk  # on a (rare) checked_at tie, last wins
+    return out
+
+
+async def latest_stats_by_server(db: AsyncSession) -> dict[int, ServerStats]:
+    """Return {server_id: latest ServerStats} in one query."""
+    subq = (
+        select(
+            ServerStats.server_id.label("sid"),
+            func.max(ServerStats.recorded_at).label("mx"),
+        )
+        .group_by(ServerStats.server_id)
+        .subquery()
+    )
+    stmt = select(ServerStats).join(
+        subq,
+        and_(ServerStats.server_id == subq.c.sid, ServerStats.recorded_at == subq.c.mx),
+    )
+    result = await db.execute(stmt)
+    out: dict[int, ServerStats] = {}
+    for st in result.scalars().all():
+        out[st.server_id] = st
+    return out

--- a/backend/routers/metrics.py
+++ b/backend/routers/metrics.py
@@ -63,9 +63,13 @@ async def prometheus_metrics(authorization: str | None = Header(default=None)):
     g_sched_running = Gauge("apt_ui_scheduler_running", "Scheduler running (1=yes, 0=no)", registry=registry)
     g_sched_unhealthy = Gauge("apt_ui_scheduler_unhealthy_jobs", "Enabled jobs not currently scheduled", registry=registry)
 
+    from backend.query_helpers import latest_checks_by_server, latest_stats_by_server
+
     async with AsyncSessionLocal() as db:
         servers_res = await db.execute(select(Server))
         servers = servers_res.scalars().all()
+        checks = await latest_checks_by_server(db)   # one query each instead of one per server
+        stats_map = await latest_stats_by_server(db)
 
         enabled = sum(1 for s in servers if s.is_enabled)
         g_servers_total.labels(enabled="true").set(enabled)
@@ -75,13 +79,7 @@ async def prometheus_metrics(authorization: str | None = Header(default=None)):
             label = s.name
             g_reachable.labels(server=label).set(1 if s.is_reachable else 0)
 
-            chk_res = await db.execute(
-                select(UpdateCheck)
-                .where(UpdateCheck.server_id == s.id)
-                .order_by(UpdateCheck.checked_at.desc())
-                .limit(1)
-            )
-            chk = chk_res.scalar_one_or_none()
+            chk = checks.get(s.id)
             if chk:
                 g_pending.labels(server=label, security="true").set(chk.security_packages or 0)
                 g_pending.labels(server=label, security="false").set(chk.regular_packages or 0)
@@ -91,13 +89,7 @@ async def prometheus_metrics(authorization: str | None = Header(default=None)):
                     age = max(0, int(time.time() - chk.checked_at.timestamp()))
                     g_last_check.labels(server=label).set(age)
 
-            stats_res = await db.execute(
-                select(ServerStats)
-                .where(ServerStats.server_id == s.id)
-                .order_by(ServerStats.recorded_at.desc())
-                .limit(1)
-            )
-            stats = stats_res.scalar_one_or_none()
+            stats = stats_map.get(s.id)
             if stats:
                 if stats.disk_usage_percent is not None:
                     g_disk.labels(server=label, mount="/").set(stats.disk_usage_percent)

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -370,12 +370,15 @@ async def list_servers(
         q = q.join(ServerGroupMembership, ServerGroupMembership.server_id == Server.id).where(
             ServerGroupMembership.group_id == group_id
         )
+    from backend.query_helpers import latest_checks_by_server
+
     result = await db.execute(q.order_by(Server.name))
     servers = result.scalars().all()
+    checks = await latest_checks_by_server(db)   # one query instead of one per server
 
     out = []
     for s in servers:
-        check = await _latest_check(s.id, db)
+        check = checks.get(s.id)
         group = None
         if s.group_id:
             g_result = await db.execute(select(ServerGroup).where(ServerGroup.id == s.group_id))

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -74,6 +74,42 @@ async def fleet_overview(
     )
 
 
+@router.get("/stats/trend")
+async def fleet_trend(
+    days: int = Query(default=30, ge=1, le=365),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Time series of fleet snapshots over the last *days* (for dashboard trend charts)."""
+    from datetime import timedelta
+    from backend.models import FleetSnapshot
+
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    res = await db.execute(
+        select(FleetSnapshot)
+        .where(FleetSnapshot.recorded_at >= cutoff)
+        .order_by(FleetSnapshot.recorded_at.asc())
+    )
+    rows = res.scalars().all()
+    return {
+        "points": [
+            {
+                "recorded_at": r.recorded_at.isoformat() if r.recorded_at else None,
+                "total_servers": r.total_servers,
+                "up_to_date": r.up_to_date,
+                "updates_available": r.updates_available,
+                "security_servers": r.security_servers,
+                "errors": r.errors,
+                "reboot_required": r.reboot_required,
+                "pending_packages_total": r.pending_packages_total,
+                "security_packages_total": r.security_packages_total,
+                "pct_up_to_date": round(100.0 * r.up_to_date / r.total_servers, 1) if r.total_servers else None,
+            }
+            for r in rows
+        ]
+    }
+
+
 @router.get("/stats/pending-updates")
 async def pending_updates(
     db: AsyncSession = Depends(get_db),

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -17,8 +17,11 @@ async def fleet_overview(
     db: AsyncSession = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
+    from backend.query_helpers import latest_checks_by_server
+
     result = await db.execute(select(Server))
     servers = result.scalars().all()
+    checks = await latest_checks_by_server(db)   # one query instead of one per server
 
     total = len(servers)
     up_to_date = 0
@@ -31,13 +34,7 @@ async def fleet_overview(
     last_check_time: datetime | None = None
 
     for server in servers:
-        check_result = await db.execute(
-            select(UpdateCheck)
-            .where(UpdateCheck.server_id == server.id)
-            .order_by(UpdateCheck.checked_at.desc())
-            .limit(1)
-        )
-        check = check_result.scalar_one_or_none()
+        check = checks.get(server.id)
         if check is None:
             continue
         if last_check_time is None or check.checked_at > last_check_time:
@@ -87,19 +84,15 @@ async def pending_updates(
     per-server /packages loop. New-dependency packages are excluded so the list count
     matches packages_available."""
     import json as _json
+    from backend.query_helpers import latest_checks_by_server
 
     result = await db.execute(select(Server).where(Server.is_enabled == True))
     servers = result.scalars().all()
+    checks = await latest_checks_by_server(db)
 
     out: list[dict] = []
     for server in servers:
-        check_result = await db.execute(
-            select(UpdateCheck)
-            .where(UpdateCheck.server_id == server.id)
-            .order_by(UpdateCheck.checked_at.desc())
-            .limit(1)
-        )
-        check = check_result.scalar_one_or_none()
+        check = checks.get(server.id)
         if check is None or check.status == "error" or (check.packages_available or 0) <= 0:
             continue
         packages: list[dict] = []

--- a/backend/routers/status_page.py
+++ b/backend/routers/status_page.py
@@ -31,9 +31,12 @@ async def status_json():
     if not PUBLIC:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
 
+    from backend.query_helpers import latest_checks_by_server
+
     async with AsyncSessionLocal() as db:
         srv_res = await db.execute(select(Server).where(Server.is_enabled == True))
         servers = srv_res.scalars().all()
+        checks = await latest_checks_by_server(db)   # one query for an unauthenticated public hit
 
         total = len(servers)
         reachable = sum(1 for s in servers if s.is_reachable)
@@ -46,13 +49,7 @@ async def status_json():
 
         items = []
         for s in servers:
-            chk_res = await db.execute(
-                select(UpdateCheck)
-                .where(UpdateCheck.server_id == s.id)
-                .order_by(UpdateCheck.checked_at.desc())
-                .limit(1)
-            )
-            chk = chk_res.scalar_one_or_none()
+            chk = checks.get(s.id)
             if not chk:
                 continue
             if chk.status == "error":

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -54,6 +54,13 @@ async def _job_check_all():
             srv_res = await db.execute(select(Server).where(Server.is_enabled == True))
             servers = srv_res.scalars().all()
             await check_all_servers(list(servers), db, concurrency)
+
+            # Record a fleet snapshot for trend charts (cheap; once per scheduled run).
+            try:
+                from backend.query_helpers import record_fleet_snapshot
+                await record_fleet_snapshot(db)
+            except Exception as exc:
+                logger.warning("Fleet snapshot failed: %s", exc)
     except Exception as exc:
         logger.error("Scheduled check-all failed: %s", exc)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -299,8 +299,22 @@ export interface PendingUpdatePkg {
   is_kernel?: boolean
 }
 
+export interface FleetTrendPoint {
+  recorded_at: string
+  total_servers: number
+  up_to_date: number
+  updates_available: number
+  security_servers: number
+  errors: number
+  reboot_required: number
+  pending_packages_total: number
+  security_packages_total: number
+  pct_up_to_date: number | null
+}
+
 export const stats = {
   overview: () => get<FleetOverview>('/api/stats/overview'),
+  trend: (days = 30) => get<{ points: FleetTrendPoint[] }>(`/api/stats/trend?days=${days}`),
   pendingUpdates: () =>
     get<{ servers: { id: number; packages: PendingUpdatePkg[] }[] }>('/api/stats/pending-updates'),
   globalHistory: (page = 1, serverId?: number, status?: string) => {

--- a/frontend/src/components/ConfirmHost.tsx
+++ b/frontend/src/components/ConfirmHost.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { useConfirmStore } from '@/hooks/useConfirm'
+
+export default function ConfirmHost() {
+  const { pending, resolve } = useConfirmStore()
+
+  useEffect(() => {
+    if (!pending) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') resolve(false)
+      if (e.key === 'Enter') resolve(true)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [pending, resolve])
+
+  if (!pending) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4"
+      onClick={() => resolve(false)}
+    >
+      <div
+        className="bg-surface border border-border rounded-lg w-full max-w-sm p-5 space-y-4 shadow-2xl"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        {pending.title && <h3 className="font-mono text-text-primary">{pending.title}</h3>}
+        <p className="text-sm text-text-muted whitespace-pre-line">{pending.message}</p>
+        <div className="flex justify-end gap-2">
+          <button onClick={() => resolve(false)} className="btn-secondary text-sm">
+            {pending.cancelLabel ?? 'Cancel'}
+          </button>
+          <button
+            onClick={() => resolve(true)}
+            className={`text-sm ${pending.danger ? 'btn-danger' : 'btn-primary'}`}
+            autoFocus
+          >
+            {pending.confirmLabel ?? 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/FleetTrendCard.tsx
+++ b/frontend/src/components/FleetTrendCard.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { stats as statsApi, type FleetTrendPoint } from '@/api/client'
+
+// Fleet trend over time, from persisted FleetSnapshot rows (written after each
+// scheduled check-all). Hidden until there are at least two data points.
+export default function FleetTrendCard() {
+  const [points, setPoints] = useState<FleetTrendPoint[]>([])
+
+  useEffect(() => {
+    statsApi.trend(30).then(r => setPoints(r.points)).catch(() => {})
+  }, [])
+
+  if (points.length < 2) return null
+
+  const data = points.map(p => ({
+    date: new Date(p.recorded_at).toLocaleDateString(),
+    pending: p.pending_packages_total,
+    security: p.security_packages_total,
+    pct: p.pct_up_to_date ?? 0,
+  }))
+
+  return (
+    <div className="card p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs text-text-muted uppercase tracking-wide">Fleet trend (30d)</h3>
+        <div className="flex items-center gap-3 text-[10px] text-text-muted font-mono">
+          <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full inline-block" style={{ background: '#f59e0b' }} />pending</span>
+          <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full inline-block" style={{ background: '#ef4444' }} />security</span>
+          <span className="flex items-center gap-1"><span className="w-2 h-2 rounded-full inline-block" style={{ background: '#22c55e' }} />% up-to-date</span>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={180}>
+        <LineChart data={data}>
+          <XAxis dataKey="date" tick={{ fill: '#6b7280', fontSize: 11 }} />
+          <YAxis yAxisId="left" tick={{ fill: '#6b7280', fontSize: 11 }} allowDecimals={false} />
+          <YAxis yAxisId="right" orientation="right" domain={[0, 100]} tick={{ fill: '#6b7280', fontSize: 11 }} />
+          <Tooltip contentStyle={{ background: '#1a1d27', border: '1px solid #2e3347', borderRadius: '4px', fontSize: '12px' }} labelStyle={{ color: '#e5e7eb' }} />
+          <Line yAxisId="left" type="monotone" dataKey="pending" name="pending" stroke="#f59e0b" dot={false} strokeWidth={1.5} />
+          <Line yAxisId="left" type="monotone" dataKey="security" name="security" stroke="#ef4444" dot={false} strokeWidth={1.5} />
+          <Line yAxisId="right" type="monotone" dataKey="pct" name="% up-to-date" stroke="#22c55e" dot={false} strokeWidth={1.5} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,6 +8,8 @@ import type { CveSummary } from '@/types'
 import type { ReleaseCheckResult } from '@/api/client'
 import type { Job } from '@/hooks/useJobStore'
 import CommandPalette from './CommandPalette'
+import ToastHost from './ToastHost'
+import ConfirmHost from './ConfirmHost'
 
 function isMac(): boolean {
   if (typeof navigator === 'undefined') return false
@@ -335,6 +337,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
 
       {/* Global command palette — opens via Ctrl/Cmd+K or the nav hint button */}
       <CommandPalette />
+
+      {/* App-wide toast + confirm dialog hosts */}
+      <ToastHost />
+      <ConfirmHost />
 
       <footer className="border-t border-border/40 px-4 py-2 text-center">
         <span className="text-xs text-text-muted font-mono">

--- a/frontend/src/components/ToastHost.tsx
+++ b/frontend/src/components/ToastHost.tsx
@@ -1,0 +1,28 @@
+import { createPortal } from 'react-dom'
+import { useToastStore } from '@/hooks/useToast'
+
+const styles: Record<string, string> = {
+  success: 'border-green/40 bg-green/10 text-green',
+  error: 'border-red/40 bg-red/10 text-red',
+  info: 'border-border bg-surface-2 text-text-primary',
+}
+
+export default function ToastHost() {
+  const { toasts, dismiss } = useToastStore()
+  if (toasts.length === 0) return null
+  return createPortal(
+    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 max-w-sm">
+      {toasts.map(t => (
+        <div
+          key={t.id}
+          onClick={() => dismiss(t.id)}
+          className={`rounded border px-3 py-2 text-sm font-mono shadow-lg cursor-pointer ${styles[t.type] ?? styles.info}`}
+          role="status"
+        >
+          {t.message}
+        </div>
+      ))}
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/hooks/useConfirm.ts
+++ b/frontend/src/hooks/useConfirm.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+
+export interface ConfirmOptions {
+  title?: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+  danger?: boolean
+}
+
+interface ConfirmState {
+  pending: (ConfirmOptions & { resolve: (v: boolean) => void }) | null
+  request: (opts: ConfirmOptions) => Promise<boolean>
+  resolve: (v: boolean) => void
+}
+
+export const useConfirmStore = create<ConfirmState>((set, get) => ({
+  pending: null,
+  request: (opts) => new Promise<boolean>(resolve => set({ pending: { ...opts, resolve } })),
+  resolve: (v) => {
+    const p = get().pending
+    if (p) p.resolve(v)
+    set({ pending: null })
+  },
+}))
+
+/** Promise-based replacement for window.confirm(). Resolves true on confirm. */
+export function confirmDialog(opts: ConfirmOptions | string): Promise<boolean> {
+  const o = typeof opts === 'string' ? { message: opts } : opts
+  return useConfirmStore.getState().request(o)
+}

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+
+export type ToastType = 'success' | 'error' | 'info'
+export interface Toast { id: number; message: string; type: ToastType }
+
+interface ToastStore {
+  toasts: Toast[]
+  push: (message: string, type?: ToastType, ms?: number) => void
+  dismiss: (id: number) => void
+}
+
+let _id = 0
+
+export const useToastStore = create<ToastStore>((set, get) => ({
+  toasts: [],
+  push: (message, type = 'info', ms = 4000) => {
+    const id = ++_id
+    set(s => ({ toasts: [...s.toasts, { id, message, type }] }))
+    if (ms > 0) setTimeout(() => get().dismiss(id), ms)
+  },
+  dismiss: (id) => set(s => ({ toasts: s.toasts.filter(t => t.id !== id) })),
+}))
+
+// Convenience helpers usable from non-component code (api handlers, stores, etc.).
+export const toast = {
+  success: (m: string) => useToastStore.getState().push(m, 'success'),
+  error: (m: string) => useToastStore.getState().push(m, 'error', 6000),
+  info: (m: string) => useToastStore.getState().push(m, 'info'),
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/hooks/useAuth'
 import { useJobStore } from '@/hooks/useJobStore'
 import { useServersStore } from '@/hooks/useServers'
 import StatusDot from '@/components/StatusDot'
+import FleetTrendCard from '@/components/FleetTrendCard'
 import UpgradeAllModal from '@/components/UpgradeAllModal'
 import AutoremoveAllModal from '@/components/AutoremoveAllModal'
 import RollingRebootModal from '@/components/RollingRebootModal'
@@ -436,6 +437,9 @@ export default function Dashboard() {
           {overview.next_check_time && ` · Next: ${new Date(overview.next_check_time).toLocaleTimeString()}`}
         </p>
       )}
+
+      {/* Fleet trend (hidden until 2+ snapshots exist) */}
+      <FleetTrendCard />
 
       {/* Combined groups + tags filter row */}
       {(groupsWithServers.length > 0 || allTags.length > 0) && (

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { servers as serversApi } from '@/api/client'
 import { useAuthStore } from '@/hooks/useAuth'
+import { confirmDialog } from '@/hooks/useConfirm'
+import { toast } from '@/hooks/useToast'
 
 type Mode = 'exact' | 'contains' | 'starts-with' | 'ends-with' | 'regex'
 
@@ -228,19 +230,18 @@ function BulkHoldButtons({
     const verb = hold ? 'Hold' : 'Unhold'
     const names = serverIds.map(id => serverNames[id]).slice(0, 5).join(', ')
     const more = serverIds.length > 5 ? ` and ${serverIds.length - 5} more` : ''
-    if (!confirm(`${verb} ${packageName} across ${serverIds.length} server(s): ${names}${more}?`)) return
+    if (!await confirmDialog({ message: `${verb} ${packageName} across ${serverIds.length} server(s): ${names}${more}?`, confirmLabel: verb })) return
     setBusy(hold ? 'hold' : 'unhold')
     try {
       const r = await serversApi.bulkHold(serverIds, packageName, hold)
       const failed = Object.entries(r.results).filter(([_, v]) => !v.success)
       if (failed.length > 0) {
-        const lines = failed.map(([sid, v]) => `${serverNames[parseInt(sid)] ?? sid}: ${v.stderr || v.stdout}`)
-        alert(`${verb} failed on ${failed.length} server(s):\n\n${lines.join('\n')}`)
+        toast.error(`${verb} failed on ${failed.length} of ${serverIds.length} server(s)`)
       } else {
-        alert(`${verb} succeeded on all ${serverIds.length} server(s).`)
+        toast.success(`${verb} succeeded on all ${serverIds.length} server(s).`)
       }
     } catch (e: unknown) {
-      alert((e as Error).message)
+      toast.error((e as Error).message)
     } finally {
       setBusy(null)
     }

--- a/frontend/src/pages/ServerDetail.tsx
+++ b/frontend/src/pages/ServerDetail.tsx
@@ -4,6 +4,8 @@ import { servers as serversApi, groups as groupsApi, tags as tagsApi, config as 
 import type { DpkgLogEntry, AptRepoFile } from '@/api/client'
 import type { Server, PackageInfo, UpdateHistory, ServerGroup, Tag } from '@/types'
 import { useJobStore } from '@/hooks/useJobStore'
+import { confirmDialog } from '@/hooks/useConfirm'
+import { toast } from '@/hooks/useToast'
 import { createUpgradeWebSocket, createSelectiveUpgradeWebSocket, createAutoremoveWebSocket, createAptUpdateWebSocket, createAutoSecurityUpdatesWebSocket, createAptProxyWebSocket, createEepromUpdateWebSocket, createDryRunWebSocket, createAptReposTestWebSocket, createPveUpgradeWebSocket } from '@/api/client'
 import DebInstallModal from '@/components/DebInstallModal'
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
@@ -961,14 +963,15 @@ function PackagesTab({ serverId, server, onRefresh }: { serverId: number; server
                                   <button
                                     onClick={async (e) => {
                                       e.stopPropagation()
-                                      if (!confirm(`Hold ${p.name} at version ${p.current_version}? It will be excluded from future upgrades.`)) return
+                                      if (!await confirmDialog({ message: `Hold ${p.name} at version ${p.current_version}? It will be excluded from future upgrades.`, confirmLabel: 'Hold' })) return
                                       try {
                                         const r = await serversApi.holdPackage(serverId, p.name, true)
-                                        if (!r.success) alert(`Hold failed: ${r.stderr || r.stdout}`)
+                                        if (!r.success) toast.error(`Hold failed: ${r.stderr || r.stdout}`)
+                                        else toast.success(`Held ${p.name}`)
                                         onRefresh()
                                         loadPackages()
                                       } catch (err: unknown) {
-                                        alert((err as Error).message)
+                                        toast.error((err as Error).message)
                                       }
                                     }}
                                     className="text-blue/80 hover:text-blue text-[11px] font-mono"
@@ -1045,14 +1048,15 @@ function PackagesTab({ serverId, server, onRefresh }: { serverId: number; server
                 {h}
                 <button
                   onClick={async () => {
-                    if (!confirm(`Unhold ${h}? It will be eligible for upgrades again.`)) return
+                    if (!await confirmDialog({ message: `Unhold ${h}? It will be eligible for upgrades again.`, confirmLabel: 'Unhold' })) return
                     try {
                       const r = await serversApi.holdPackage(serverId, h, false)
-                      if (!r.success) alert(`Unhold failed: ${r.stderr || r.stdout}`)
+                      if (!r.success) toast.error(`Unhold failed: ${r.stderr || r.stdout}`)
+                      else toast.success(`Unheld ${h}`)
                       onRefresh()
                       loadPackages()
                     } catch (e: unknown) {
-                      alert((e as Error).message)
+                      toast.error((e as Error).message)
                     }
                   }}
                   className="hover:text-red text-blue/70"
@@ -2131,7 +2135,7 @@ function AptReposTab({ serverId }: { serverId: number }) {
 
   async function deleteFile() {
     if (!selectedPath || !currentFile?.deletable) return
-    if (!window.confirm(`Delete ${selectedPath}?\n\nThis cannot be undone.`)) return
+    if (!await confirmDialog({ message: `Delete ${selectedPath}?\n\nThis cannot be undone.`, confirmLabel: 'Delete', danger: true })) return
     setDeleting(true)
     setSaveError(null)
     try {
@@ -2410,14 +2414,15 @@ function HealthTab({ serverId }: { serverId: number }) {
   useEffect(() => { load() }, [load])
 
   async function restart(unit: string) {
-    if (!confirm(`Restart ${unit}?`)) return
+    if (!await confirmDialog({ message: `Restart ${unit}?`, confirmLabel: 'Restart' })) return
     setRestarting(unit)
     try {
       const r = await serversApi.restartService(serverId, unit)
-      if (!r.success) alert(`Restart failed: ${r.stderr || r.stdout || 'unknown error'}`)
+      if (!r.success) toast.error(`Restart failed: ${r.stderr || r.stdout || 'unknown error'}`)
+      else toast.success(`Restarted ${unit}`)
       await load()
     } catch (e: unknown) {
-      alert((e as Error).message)
+      toast.error((e as Error).message)
     } finally {
       setRestarting(null)
     }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -5,6 +5,8 @@ import { servers as serversApi, groups as groupsApi, tags as tagsApi, scheduler 
 import type { MaintenanceWindow, UpgradeHook } from '@/api/client'
 import type { Server, ServerGroup, ScheduleConfig, NotificationConfig, Tag, AptCacheServer, TailscaleStatus } from '@/types'
 import { useAuthStore } from '@/hooks/useAuth'
+import { confirmDialog } from '@/hooks/useConfirm'
+import { toast } from '@/hooks/useToast'
 
 const TABS = ['Servers', 'Schedule', 'Preferences', 'Notifications', 'Infrastructure', 'Users', 'Account', 'Backup'] as const
 type Tab = typeof TABS[number]
@@ -299,7 +301,7 @@ function ServersTab() {
   }
 
   async function handleDeleteServer(id: number) {
-    if (!confirm('Delete this server and all its history?')) return
+    if (!await confirmDialog({ message: 'Delete this server and all its history?', confirmLabel: 'Delete', danger: true })) return
     await serversApi.remove(id)
     setSelectedIds(prev => { const n = new Set(prev); n.delete(id); return n })
     load()
@@ -307,7 +309,7 @@ function ServersTab() {
 
   async function handleBulkDelete() {
     const count = selectedIds.size
-    if (!confirm(`Delete ${count} server${count === 1 ? '' : 's'} and all their history? This cannot be undone.`)) return
+    if (!await confirmDialog({ message: `Delete ${count} server${count === 1 ? '' : 's'} and all their history? This cannot be undone.`, confirmLabel: 'Delete', danger: true })) return
     setBulkDeleting(true)
     try {
       await Promise.all([...selectedIds].map(id => serversApi.remove(id)))
@@ -335,7 +337,7 @@ function ServersTab() {
   }
 
   async function handleDeleteGroup(id: number) {
-    if (!confirm('Delete this group? Servers will be unassigned.')) return
+    if (!await confirmDialog({ message: 'Delete this group? Servers will be unassigned.', confirmLabel: 'Delete', danger: true })) return
     await groupsApi.remove(id)
     load()
   }
@@ -364,7 +366,7 @@ function ServersTab() {
   }
 
   async function handleDeleteTag(id: number) {
-    if (!confirm('Delete this tag? It will be removed from all servers.')) return
+    if (!await confirmDialog({ message: 'Delete this tag? It will be removed from all servers.', confirmLabel: 'Delete', danger: true })) return
     await tagsApi.remove(id)
     load()
   }
@@ -552,10 +554,10 @@ function ServersTab() {
                 if (!file) return
                 try {
                   const result = await configApi.importCsv(file)
-                  alert(`Imported: ${result.added} added, ${result.skipped} skipped`)
+                  toast.success(`Imported: ${result.added} added, ${result.skipped} skipped`)
                   load()
                 } catch (err: unknown) {
-                  alert('Import failed: ' + (err instanceof Error ? err.message : String(err)))
+                  toast.error('Import failed: ' + (err instanceof Error ? err.message : String(err)))
                 }
                 e.target.value = ''
               }}
@@ -1321,7 +1323,7 @@ function MaintenanceWindowsSection() {
   }
 
   async function remove(id: number) {
-    if (!confirm('Delete this maintenance window?')) return
+    if (!await confirmDialog({ message: 'Delete this maintenance window?', confirmLabel: 'Delete', danger: true })) return
     await maintenanceApi.remove(id)
     await reload()
   }
@@ -1699,7 +1701,7 @@ function UpgradeHooksSection() {
   }
 
   async function remove(id: number) {
-    if (!confirm('Delete this hook?')) return
+    if (!await confirmDialog({ message: 'Delete this hook?', confirmLabel: 'Delete', danger: true })) return
     await hooksApi.remove(id)
     await reload()
   }
@@ -2641,17 +2643,17 @@ function UsersTab() {
       await auth.updateUser(u.id, { is_admin: !u.is_admin })
       await reload()
     } catch (e: unknown) {
-      alert((e as Error).message)
+      toast.error((e as Error).message)
     }
   }
 
   async function remove(u: import('@/api/client').UserSummary) {
-    if (!confirm(`Delete user "${u.username}"? This also revokes all their API tokens.`)) return
+    if (!await confirmDialog({ message: `Delete user "${u.username}"? This also revokes all their API tokens.`, confirmLabel: 'Delete', danger: true })) return
     try {
       await auth.deleteUser(u.id)
       await reload()
     } catch (e: unknown) {
-      alert((e as Error).message)
+      toast.error((e as Error).message)
     }
   }
 
@@ -3091,7 +3093,7 @@ function ApiTokensSection() {
   }
 
   async function revoke(id: number) {
-    if (!confirm('Revoke this token? Any scripts using it will stop working.')) return
+    if (!await confirmDialog({ message: 'Revoke this token? Any scripts using it will stop working.', confirmLabel: 'Revoke', danger: true })) return
     await auth.revokeToken(id)
     await reload()
   }
@@ -3184,7 +3186,7 @@ function BackupTab() {
       a.click()
       URL.revokeObjectURL(url)
     } catch (e: unknown) {
-      alert('Export failed: ' + (e instanceof Error ? e.message : String(e)))
+      toast.error('Export failed: ' + (e instanceof Error ? e.message : String(e)))
     } finally {
       setExporting(false)
     }

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { servers as serversApi, templates as templatesApi, createTemplateApplyWebSocket } from '@/api/client'
+import { confirmDialog } from '@/hooks/useConfirm'
+import { toast } from '@/hooks/useToast'
 import type { Template, TemplatePackage, Server } from '@/types'
 import Convert from 'ansi-to-html'
 
@@ -34,10 +36,12 @@ export default function Templates() {
   useEffect(() => { load() }, [load])
 
   async function handleDelete(id: number) {
-    if (!confirm('Delete this template?')) return
-    await templatesApi.remove(id)
-    if (selected?.id === id) setSelected(null)
-    load()
+    if (!await confirmDialog({ message: 'Delete this template?', confirmLabel: 'Delete', danger: true })) return
+    try {
+      await templatesApi.remove(id)
+      if (selected?.id === id) setSelected(null)
+      load()
+    } catch (e) { toast.error((e as Error).message) }
   }
 
   return (


### PR DESCRIPTION
High-impact bets tier of the roadmap (#62) — **part 1 of the tier (3 of 11)**: the foundational and highest-leverage items. Stacked on #64 (quick-wins), so review #64 first; this PR's base is `feature/roadmap-quick-wins` and the diff below is just the high-impact changes.

Part of #62 (high-impact tier). The remaining 8 bets are queued (see "Still to come").

## In this PR

1. **App-wide toast + styled confirm system** (`d1058e4`)
   `useToast` + `<ToastHost>` (auto-dismiss, typed styles) and `useConfirm` + `<ConfirmHost>` + promise-based `confirmDialog()` replacing native `window.confirm` (Esc/Enter, danger styling, themed). Both mounted in Layout. **Migrated all ~28 native `alert()`/`confirm()` sites** across Settings/ServerDetail/Search/Templates. This unblocks the bulk action bar and any future flow needing decent feedback.

2. **Eliminate the per-server latest-row N+1** (`efc13fe`)
   New `backend/query_helpers.py` fetches the latest `UpdateCheck`/`ServerStats` for every server in one query each. Refactored the hottest callers off their per-server loops: `/stats/overview`, `/stats/pending-updates`, `/metrics`, `/status.json`, and `list_servers` — paths that run on every 30s dashboard poll, every metrics scrape, and every public status hit.

3. **Fleet snapshot history + trend chart** (`5089655`)
   New `FleetSnapshot` table written after each scheduled check-all (`record_fleet_snapshot`), excluded from the log purge; `GET /api/stats/trend?days=N`; a `FleetTrendCard` on the dashboard (pending packages, security packages, % up-to-date over 30d), hidden until ≥2 snapshots exist.

## Still to come (remaining 8 high-impact bets, in their own follow-up PRs)
- Unified actor attribution + `AuthEventLog` (+ History sub-tab)
- Login/2FA brute-force lockout + alerting
- Dashboard bulk selection + sticky action bar (will use the new toast/confirm)
- Enforce maintenance windows as gates on all mutating actions + override
- Snapshot-and-rollback safety net
- Canary-first auto-upgrade with health verification
- Multi-target notifications + on-call adapters
- Inbound `/api/v1` + scoped/expiring tokens

## DB
- New table `fleet_snapshots` (auto-created by `Base.metadata.create_all`; no migration entry needed per project convention).

## Testing
- ✅ `make ci` (Python syntax + import check + frontend `tsc`/vite build) — green.
- ⬜ Runtime verification recommended for: toast/confirm flows on destructive actions, trend chart after snapshots accrue, and the refactored hot endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
