### PR TITLE
feat: roadmap high-impact (security/audit): actor attribution, auth log, brute-force, window enforcement — #62

### DIFF
--- a/backend/actor.py
+++ b/backend/actor.py
@@ -1,0 +1,22 @@
+"""Ambient "who initiated this action" identity, threaded via a ContextVar.
+
+WebSocket / request handlers call set_actor(username) after authenticating; the SSH
+audit log and upgrade-history writers read get_actor() instead of hard-coding "system".
+ContextVars propagate into coroutines and tasks spawned from the same context
+(asyncio.create_task / gather copy the current context), so per-server fan-out keeps
+the right actor. Background/scheduled jobs never set it, so they remain "system".
+"""
+import contextvars
+
+_actor: contextvars.ContextVar[str] = contextvars.ContextVar("apt_ui_actor", default="system")
+
+
+def set_actor(name: str | None) -> None:
+    _actor.set(name or "system")
+
+
+def get_actor() -> str:
+    try:
+        return _actor.get() or "system"
+    except LookupError:
+        return "system"

--- a/backend/database.py
+++ b/backend/database.py
@@ -215,7 +215,10 @@ async def init_db():
             "ALTER TABLE schedule_config ADD COLUMN reboot_batch_size INTEGER DEFAULT 3",
             "ALTER TABLE schedule_config ADD COLUMN reboot_batch_wait_minutes INTEGER DEFAULT 5",
             "ALTER TABLE schedule_config ADD COLUMN reboot_timeout_minutes INTEGER DEFAULT 10",
+            # TOTP replay protection (issue #62)
+            "ALTER TABLE users ADD COLUMN totp_last_counter INTEGER",
             # api_tokens table is created by Base.metadata.create_all (new table — no migration needed)
+            # auth_event_log + fleet_snapshots are new tables — created by create_all, no migration needed
         ]
         for sql in migrations:
             try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,8 @@ class User(Base):
     # TOTP 2FA (issue #18) — secret stored Fernet-encrypted via backend.crypto
     totp_secret_enc: Mapped[str | None] = mapped_column(Text, nullable=True)
     totp_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Last TOTP step counter accepted at login — blocks code replay (issue #62).
+    totp_last_counter: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class MaintenanceWindow(Base):
@@ -405,6 +407,21 @@ class TemplatePackage(Base):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     template: Mapped["Template"] = relationship("Template", back_populates="packages")
+
+
+class AuthEventLog(Base):
+    """Security/auth audit trail: logins, failures, logout, token + user + 2FA changes,
+    lockouts. Surfaced as a History sub-tab."""
+    __tablename__ = "auth_event_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), index=True)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)  # login / login_failed / logout / ...
+    username: Mapped[str | None] = mapped_column(Text, nullable=True)   # subject of the event
+    actor: Mapped[str | None] = mapped_column(Text, nullable=True)      # who performed it (admin actions)
+    ip_address: Mapped[str | None] = mapped_column(Text, nullable=True)
+    detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    success: Mapped[bool] = mapped_column(Boolean, default=True)
 
 
 class FleetSnapshot(Base):

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,7 +1,9 @@
+import logging
+import time
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import bcrypt
@@ -15,25 +17,127 @@ from backend.auth import (
     verify_password,
 )
 from backend.database import get_db
-from backend.models import ApiToken, User
+from backend.models import ApiToken, AuthEventLog, User
 from backend.schemas import ChangePasswordRequest, LoginRequest, UserOut
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 COOKIE_NAME = "apt_ui_token"
 COOKIE_MAX_AGE = 60 * 60 * 24  # 24 hours
 
+# ---------------------------------------------------------------------------
+# Brute-force protection (issue #62) — in-memory per (username, ip) tracker.
+# Resets on container restart, which is acceptable for a self-hosted single node.
+# ---------------------------------------------------------------------------
+_MAX_ATTEMPTS = 5
+_WINDOW_SECONDS = 15 * 60
+_LOCKOUT_SECONDS = 15 * 60
+_attempts: dict[tuple[str, str], list[float]] = {}
+_locked_until: dict[tuple[str, str], float] = {}
+
+
+def _client_ip(request: Request | None) -> str:
+    if request is None:
+        return "unknown"
+    fwd = request.headers.get("x-forwarded-for")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _lockout_remaining(key: tuple[str, str]) -> int:
+    until = _locked_until.get(key)
+    if until and until > time.time():
+        return int(until - time.time())
+    return 0
+
+
+def _record_failure(key: tuple[str, str]) -> bool:
+    """Record a failed attempt; return True if this trips a fresh lockout."""
+    now = time.time()
+    recent = [t for t in _attempts.get(key, []) if now - t < _WINDOW_SECONDS]
+    recent.append(now)
+    _attempts[key] = recent
+    if len(recent) >= _MAX_ATTEMPTS:
+        _locked_until[key] = now + _LOCKOUT_SECONDS
+        _attempts[key] = []
+        return True
+    return False
+
+
+def _clear_attempts(key: tuple[str, str]) -> None:
+    _attempts.pop(key, None)
+    _locked_until.pop(key, None)
+
+
+async def record_auth_event(db, event_type: str, username: str | None = None,
+                            actor: str | None = None, ip: str | None = None,
+                            detail: str | None = None, success: bool = True) -> None:
+    """Best-effort append to the auth event log."""
+    try:
+        db.add(AuthEventLog(
+            event_type=event_type, username=username, actor=actor,
+            ip_address=ip, detail=detail, success=success,
+        ))
+        await db.commit()
+    except Exception as exc:
+        logger.debug("auth event write failed: %s", exc)
+
+
+async def _alert_lockout(username: str, ip: str) -> None:
+    """Fire a notification when an account locks out (best-effort), via whatever
+    simple channels are enabled."""
+    try:
+        from backend.database import AsyncSessionLocal
+        from backend.models import NotificationConfig
+        from backend import notifier
+        msg = f"🔒 apt-ui: account '{username}' locked after {_MAX_ATTEMPTS} failed logins from {ip}."
+        async with AsyncSessionLocal() as ndb:
+            cfg = (await ndb.execute(select(NotificationConfig).where(NotificationConfig.id == 1))).scalar_one_or_none()
+            if not cfg:
+                return
+            if getattr(cfg, "telegram_enabled", False):
+                await notifier._send_telegram(cfg, msg, event_type="lockout")
+            if getattr(cfg, "slack_enabled", False):
+                await notifier._send_slack(cfg, "Account lockout", body=msg, event_type="lockout")
+            if getattr(cfg, "webhook_enabled", False):
+                await notifier._send_webhook(cfg, "lockout", {"username": username, "ip": ip, "attempts": _MAX_ATTEMPTS})
+    except Exception as exc:
+        logger.debug("lockout alert failed: %s", exc)
+
 
 @router.post("/login")
 async def login(
     body: LoginRequest,
+    request: Request,
     response: Response,
     db: AsyncSession = Depends(get_db),
 ):
+    ip = _client_ip(request)
+    key = ((body.username or "").lower().strip(), ip)
+
+    # Brute-force lockout gate
+    remaining = _lockout_remaining(key)
+    if remaining > 0:
+        await record_auth_event(db, "login_blocked", username=body.username, ip=ip,
+                                detail=f"locked ({remaining}s remaining)", success=False)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Too many failed attempts. Try again in {remaining // 60 + 1} min.",
+        )
+
     result = await db.execute(select(User).where(User.username == body.username))
     user = result.scalar_one_or_none()
 
     if user is None or not verify_password(body.password, user.password_hash):
+        tripped = _record_failure(key)
+        await record_auth_event(db, "login_failed", username=body.username, ip=ip,
+                                detail="invalid credentials", success=False)
+        if tripped:
+            await record_auth_event(db, "lockout", username=body.username, ip=ip,
+                                    detail=f"locked for {_LOCKOUT_SECONDS // 60} min", success=False)
+            await _alert_lockout(body.username, ip)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid credentials",
@@ -54,15 +158,30 @@ async def login(
             secret = decrypt(user.totp_secret_enc)
             totp = pyotp.TOTP(secret)
             if not totp.verify(code, valid_window=1):
+                tripped = _record_failure(key)
+                await record_auth_event(db, "login_failed", username=body.username, ip=ip,
+                                        detail="invalid 2FA code", success=False)
+                if tripped:
+                    await record_auth_event(db, "lockout", username=body.username, ip=ip,
+                                            detail="repeated 2FA failures", success=False)
+                    await _alert_lockout(body.username, ip)
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid 2FA code")
+            # Replay protection: reject a code from a TOTP step already used to log in.
+            counter = int(time.time()) // 30
+            if user.totp_last_counter is not None and counter <= user.totp_last_counter:
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                                    detail="2FA code already used; wait for the next code")
+            user.totp_last_counter = counter
         except HTTPException:
             raise
         except Exception:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="2FA verification failed")
 
+    _clear_attempts(key)
     user.last_login = datetime.now(timezone.utc)
     await db.commit()
     await db.refresh(user)
+    await record_auth_event(db, "login", username=user.username, ip=ip, success=True)
 
     token = create_access_token(user.username)
     response.set_cookie(
@@ -160,13 +279,16 @@ async def create_token(
     db.add(tok)
     await db.commit()
     await db.refresh(tok)
-    return {
+    result = {
         "id": tok.id,
         "name": tok.name,
         "prefix": tok.token_prefix,
         "token": raw,  # shown ONCE
         "created_at": tok.created_at,
     }
+    await record_auth_event(db, "token_created", username=current_user.username,
+                            actor=current_user.username, detail=name)
+    return result
 
 
 @router.delete("/tokens/{token_id}")
@@ -181,8 +303,11 @@ async def revoke_token(
     tok = res.scalar_one_or_none()
     if tok is None:
         raise HTTPException(status_code=404, detail="Token not found")
+    tok_name = tok.name
     await db.delete(tok)
     await db.commit()
+    await record_auth_event(db, "token_revoked", username=current_user.username,
+                            actor=current_user.username, detail=tok_name)
     return {"detail": "Token revoked"}
 
 
@@ -251,6 +376,7 @@ async def totp_verify(
 
     user.totp_enabled = True
     await db.commit()
+    await record_auth_event(db, "2fa_enabled", username=user.username, actor=user.username)
     return {"detail": "2FA enabled"}
 
 
@@ -267,7 +393,9 @@ async def totp_disable(
     user = res.scalar_one()
     user.totp_enabled = False
     user.totp_secret_enc = None
+    user.totp_last_counter = None
     await db.commit()
+    await record_auth_event(db, "2fa_disabled", username=user.username, actor=user.username)
     return {"detail": "2FA disabled"}
 
 
@@ -328,6 +456,8 @@ async def create_user(
     db.add(user)
     await db.commit()
     await db.refresh(user)
+    await record_auth_event(db, "user_created", username=user.username,
+                            actor=current_user.username, detail="admin" if is_admin else "user")
     return _user_dict(user)
 
 
@@ -363,6 +493,13 @@ async def update_user(
 
     await db.commit()
     await db.refresh(user)
+    changes = []
+    if "is_admin" in body:
+        changes.append("admin" if user.is_admin else "non-admin")
+    if body.get("password"):
+        changes.append("password reset")
+    await record_auth_event(db, "user_updated", username=user.username,
+                            actor=current_user.username, detail=", ".join(changes) or None)
     return _user_dict(user)
 
 
@@ -386,8 +523,45 @@ async def delete_user(
         if other_admins.scalar_one_or_none() is None:
             raise HTTPException(status_code=400, detail="Cannot delete the last admin")
     # Cascade-delete the user's API tokens
+    deleted_username = user.username
     tokens_res = await db.execute(select(ApiToken).where(ApiToken.user_id == user_id))
     for tok in tokens_res.scalars().all():
         await db.delete(tok)
     await db.delete(user)
     await db.commit()
+    await record_auth_event(db, "user_deleted", username=deleted_username,
+                            actor=current_user.username)
+
+
+# ---------------------------------------------------------------------------
+# Auth event log (issue #62) — admin-only audit trail
+# ---------------------------------------------------------------------------
+
+@router.get("/events")
+async def list_auth_events(
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=50, ge=1, le=200),
+    _: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    total = (await db.execute(select(func.count()).select_from(AuthEventLog))).scalar() or 0
+    res = await db.execute(
+        select(AuthEventLog)
+        .order_by(AuthEventLog.created_at.desc())
+        .offset((page - 1) * limit)
+        .limit(limit)
+    )
+    items = [
+        {
+            "id": e.id,
+            "created_at": e.created_at,
+            "event_type": e.event_type,
+            "username": e.username,
+            "actor": e.actor,
+            "ip_address": e.ip_address,
+            "detail": e.detail,
+            "success": e.success,
+        }
+        for e in res.scalars().all()
+    ]
+    return {"total": total, "page": page, "limit": limit, "items": items}

--- a/backend/routers/maintenance.py
+++ b/backend/routers/maintenance.py
@@ -56,6 +56,18 @@ async def get_active_window_for_server(db: AsyncSession, server_id: int) -> Main
     return None
 
 
+async def window_block_reason(db: AsyncSession, server_id: int, override: bool = False) -> str | None:
+    """Return a human-readable reason if a mutating action on *server_id* is currently
+    blocked by an active maintenance (deny) window, or None if allowed. `override=True`
+    (admin) bypasses the gate."""
+    if override:
+        return None
+    w = await get_active_window_for_server(db, server_id)
+    if w is not None:
+        return f"blocked by maintenance window '{w.name}'"
+    return None
+
+
 # ---------------------------------------------------------------------------
 # CRUD
 # ---------------------------------------------------------------------------

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -635,11 +635,16 @@ async def clear_server_ssh_key(
 @router.post("/{server_id}/reboot")
 async def reboot_server(
     server_id: int,
+    override_window: bool = Query(default=False),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(require_admin),
 ):
     set_actor(user.username)
     server = await _get_server_or_404(server_id, db)
+    from backend.routers.maintenance import window_block_reason
+    block = await window_block_reason(db, server_id, override=override_window)
+    if block:
+        return {"success": False, "detail": f"Reboot {block}. Pass ?override_window=true to override."}
     sudo = "" if server.username == "root" else "sudo "
     result = await run_command(server, f"{sudo}reboot", timeout=15)
     # SSH will drop mid-command on reboot — exit code 255 is normal here

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.actor import set_actor
 from backend.auth import get_current_user, require_admin
 from backend.database import get_db
 from backend.eol_data import get_eol_status_from_os_info
@@ -635,8 +636,9 @@ async def clear_server_ssh_key(
 async def reboot_server(
     server_id: int,
     db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_admin),
+    user: User = Depends(require_admin),
 ):
+    set_actor(user.username)
     server = await _get_server_or_404(server_id, db)
     sudo = "" if server.username == "root" else "sudo "
     result = await run_command(server, f"{sudo}reboot", timeout=15)
@@ -1048,13 +1050,14 @@ async def hold_package(
     server_id: int,
     body: dict,
     db: AsyncSession = Depends(get_db),
-    _: User = Depends(require_admin),
+    user: User = Depends(require_admin),
 ):
     """Hold or unhold a package via apt-mark (issue #26).
 
     Body: {"package": "nginx", "hold": true | false}
     """
     import re as _re
+    set_actor(user.username)
     server = await _get_server_or_404(server_id, db)
     pkg = (body.get("package") or "").strip()
     hold = bool(body.get("hold", True))
@@ -1077,10 +1080,11 @@ async def restart_service(
     server_id: int,
     body: dict,
     db: AsyncSession = Depends(get_db),
-    _: User = Depends(get_current_user),
+    user: User = Depends(get_current_user),
 ):
     """Restart a systemd service (issue #42)."""
     import re as _re
+    set_actor(user.username)
     server = await _get_server_or_404(server_id, db)
     unit = (body.get("unit") or "").strip()
     if not unit or not _re.match(r'^[a-zA-Z0-9@.\-_:]+\.(service|socket|timer|target|path|mount)$', unit):

--- a/backend/routers/upgrades.py
+++ b/backend/routers/upgrades.py
@@ -712,6 +712,15 @@ async def ws_upgrade(websocket: WebSocket, server_id: int):
         allow_phased = params.get("allow_phased", False)
         conffile_action = params.get("conffile_action", "confdef_confold")
         reboot_if_required = params.get("reboot_if_required", False)
+        override_window = bool(params.get("override_window", False))
+
+        # Maintenance-window gate (admins may override)
+        from backend.routers.maintenance import window_block_reason
+        block = await window_block_reason(db, server_id, override=override_window and user.is_admin)
+        if block:
+            await websocket.send_json({"type": "error", "data": f"Upgrade {block}. An admin can override."})
+            await websocket.close()
+            return
 
         cfg_res = await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))
         cfg = cfg_res.scalar_one_or_none()
@@ -843,6 +852,7 @@ async def ws_upgrade_all(websocket: WebSocket):
         # Optional explicit target set (e.g. the dashboard's active filter). When omitted
         # we fall back to every enabled server, preserving the original behaviour.
         explicit_ids = params.get("server_ids") or None
+        override_window = bool(params.get("override_window", False)) and user.is_admin
 
         cfg_res = await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))
         cfg = cfg_res.scalar_one_or_none()
@@ -855,6 +865,7 @@ async def ws_upgrade_all(websocket: WebSocket):
         srv_res = await db.execute(srv_query)
         servers = srv_res.scalars().all()
 
+        from backend.routers.maintenance import window_block_reason
         to_upgrade = []
         for s in servers:
             chk_res = await db.execute(
@@ -864,8 +875,17 @@ async def ws_upgrade_all(websocket: WebSocket):
                 .limit(1)
             )
             chk = chk_res.scalar_one_or_none()
-            if chk and chk.status == "success" and chk.packages_available > 0:
-                to_upgrade.append(s)
+            if not (chk and chk.status == "success" and chk.packages_available > 0):
+                continue
+            block = await window_block_reason(db, s.id, override=override_window)
+            if block:
+                try:
+                    await websocket.send_json({"type": "error", "server_id": s.id, "server_name": s.name,
+                                               "data": f"Skipped — {block}."})
+                except Exception:
+                    pass
+                continue
+            to_upgrade.append(s)
 
     semaphore = asyncio.Semaphore(concurrency)
     histories: list = []

--- a/backend/routers/upgrades.py
+++ b/backend/routers/upgrades.py
@@ -16,6 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.auth import get_current_user, get_current_user_ws
+from backend.actor import set_actor
 from backend.config import ENABLE_TERMINAL
 from backend.database import get_db, AsyncSessionLocal
 from backend.models import Server, ScheduleConfig, UpdateCheck, User
@@ -136,6 +137,7 @@ async def ws_install(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -219,6 +221,7 @@ async def ws_auto_security_updates(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -302,6 +305,7 @@ async def ws_apt_proxy(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -410,6 +414,7 @@ async def ws_eeprom_update(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -477,6 +482,7 @@ async def ws_pveupgrade(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -558,6 +564,7 @@ async def ws_dry_run(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -685,6 +692,7 @@ async def ws_upgrade(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server = await db.execute(select(Server).where(Server.id == server_id))
         server = server.scalar_one_or_none()
@@ -752,6 +760,7 @@ async def ws_upgrade_selective(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -819,6 +828,7 @@ async def ws_upgrade_all(websocket: WebSocket):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         try:
             raw = await asyncio.wait_for(websocket.receive_text(), timeout=10)
@@ -927,6 +937,7 @@ async def ws_shell(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -1018,6 +1029,7 @@ async def ws_template_apply(websocket: WebSocket, template_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         from backend.models import Template, TemplatePackage
         template_result = await db.execute(select(Template).where(Template.id == template_id))
@@ -1158,6 +1170,7 @@ async def ws_apt_update(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -1206,6 +1219,7 @@ async def ws_autoremove(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()
@@ -1262,6 +1276,7 @@ async def ws_autoremove_all(websocket: WebSocket):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         try:
             raw = await asyncio.wait_for(websocket.receive_text(), timeout=10)
@@ -1385,6 +1400,7 @@ async def ws_reboot_all(websocket: WebSocket):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         try:
             raw = await asyncio.wait_for(websocket.receive_text(), timeout=10)
@@ -1730,6 +1746,7 @@ async def ws_install_deb(websocket: WebSocket, server_id: int):
         if user is None:
             await websocket.close(code=1008)
             return
+        set_actor(user.username)
 
         server_result = await db.execute(select(Server).where(Server.id == server_id))
         server = server_result.scalar_one_or_none()

--- a/backend/ssh_manager.py
+++ b/backend/ssh_manager.py
@@ -165,6 +165,7 @@ async def _audit_log(server_id: int, command: str, result: "CommandResult", dura
     try:
         from backend.database import AsyncSessionLocal
         from backend.models import SshAuditLog
+        from backend.actor import get_actor
         excerpt = ((result.stdout or "") + (result.stderr or ""))[:4096]
         async with AsyncSessionLocal() as db:
             db.add(SshAuditLog(
@@ -173,7 +174,7 @@ async def _audit_log(server_id: int, command: str, result: "CommandResult", dura
                 exit_code=result.exit_code,
                 output_excerpt=excerpt or None,
                 duration_ms=duration_ms,
-                initiated_by="system",
+                initiated_by=get_actor(),
             ))
             await db.commit()
     except Exception as exc:

--- a/backend/upgrade_manager.py
+++ b/backend/upgrade_manager.py
@@ -20,6 +20,7 @@ from sqlalchemy import select
 from backend.models import Server, UpdateCheck, UpdateHistory
 from backend.ssh_manager import run_command, run_command_stream
 from backend.update_checker import check_server
+from backend.actor import get_actor
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ async def upgrade_server(
     action: str = "upgrade",
     allow_phased: bool = False,
     conffile_action: str = "confdef_confold",
-    initiated_by: str = "manual",
+    initiated_by: str | None = None,
     send_fn=None,
     skip_notify: bool = False,
     run_apt_update: bool = False,
@@ -127,7 +128,7 @@ async def upgrade_server(
             action=action,
             phased_updates=allow_phased,
             log_output=msg,
-            initiated_by=initiated_by,
+            initiated_by=(initiated_by or get_actor()),
         )
         db.add(history)
         await db.commit()
@@ -143,7 +144,7 @@ async def upgrade_server(
                 status="running",
                 action=action,
                 phased_updates=allow_phased,
-                initiated_by=initiated_by,
+                initiated_by=(initiated_by or get_actor()),
             )
             db.add(history)
             await db.commit()
@@ -316,7 +317,7 @@ async def upgrade_packages_selective(
     db: AsyncSession,
     packages: list[str],
     allow_phased: bool = False,
-    initiated_by: str = "manual",
+    initiated_by: str | None = None,
     send_fn=None,
     run_apt_update: bool = False,
 ) -> UpdateHistory:
@@ -342,7 +343,7 @@ async def upgrade_packages_selective(
             action="selective",
             phased_updates=allow_phased,
             log_output=msg,
-            initiated_by=initiated_by,
+            initiated_by=(initiated_by or get_actor()),
         )
         db.add(history)
         await db.commit()
@@ -358,7 +359,7 @@ async def upgrade_packages_selective(
                 status="running",
                 action="selective",
                 phased_updates=allow_phased,
-                initiated_by=initiated_by,
+                initiated_by=(initiated_by or get_actor()),
             )
             db.add(history)
             await db.commit()
@@ -450,7 +451,7 @@ async def run_autoremove(
     server: Server,
     db: AsyncSession,
     packages: list[str] | None = None,
-    initiated_by: str = "manual",
+    initiated_by: str | None = None,
     send_fn=None,
 ) -> UpdateHistory:
     """
@@ -475,7 +476,7 @@ async def run_autoremove(
             action="autoremove",
             phased_updates=False,
             log_output=msg,
-            initiated_by=initiated_by,
+            initiated_by=(initiated_by or get_actor()),
         )
         db.add(history)
         await db.commit()
@@ -491,7 +492,7 @@ async def run_autoremove(
                 status="running",
                 action="autoremove",
                 phased_updates=False,
-                initiated_by=initiated_by,
+                initiated_by=(initiated_by or get_actor()),
             )
             db.add(history)
             await db.commit()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -117,6 +117,21 @@ export const auth = {
   updateUser: (id: number, data: { is_admin?: boolean; password?: string }) =>
     put<UserSummary>(`/api/auth/users/${id}`, data),
   deleteUser: (id: number) => del(`/api/auth/users/${id}`),
+  events: (page = 1, limit = 50) =>
+    get<{ total: number; page: number; limit: number; items: AuthEvent[] }>(
+      `/api/auth/events?page=${page}&limit=${limit}`
+    ),
+}
+
+export interface AuthEvent {
+  id: number
+  created_at: string
+  event_type: string
+  username: string | null
+  actor: string | null
+  ip_address: string | null
+  detail: string | null
+  success: boolean
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { stats as statsApi, servers as serversApi, notifications as notifApi, sshAudit as sshAuditApi } from '@/api/client'
+import { stats as statsApi, servers as serversApi, notifications as notifApi, sshAudit as sshAuditApi, auth as authApi } from '@/api/client'
 import type { UpdateHistory, Server, NotificationLog } from '@/types'
+import { useAuthStore } from '@/hooks/useAuth'
 
 type HistoryItem = UpdateHistory & { server_name: string }
 
@@ -291,10 +292,12 @@ function NotificationHistory() {
   )
 }
 
-const TABS = ['Upgrade History', 'Notification History', 'SSH Audit Log'] as const
-type Tab = typeof TABS[number]
+const ALL_TABS = ['Upgrade History', 'Notification History', 'SSH Audit Log', 'Auth Events'] as const
+type Tab = typeof ALL_TABS[number]
 
 export default function History() {
+  const { user } = useAuthStore()
+  const tabs = ALL_TABS.filter(t => t !== 'Auth Events' || user?.is_admin)  // auth log is admin-only
   const [tab, setTab] = useState<Tab>('Upgrade History')
 
   return (
@@ -302,7 +305,7 @@ export default function History() {
       <h1 className="text-lg font-mono text-text-primary">History</h1>
 
       <div className="flex gap-1 border-b border-border">
-        {TABS.map(t => (
+        {tabs.map(t => (
           <button
             key={t}
             onClick={() => setTab(t)}
@@ -320,6 +323,7 @@ export default function History() {
       {tab === 'Upgrade History' && <UpdateHistory />}
       {tab === 'Notification History' && <NotificationHistory />}
       {tab === 'SSH Audit Log' && <SshAuditHistory />}
+      {tab === 'Auth Events' && <AuthEventsHistory />}
     </div>
   )
 }
@@ -425,6 +429,90 @@ function SshAuditHistory() {
                       </tr>
                     )}
                   </>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2">
+              <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page <= 1} className="btn-secondary text-xs">← Prev</button>
+              <span className="text-sm text-text-muted font-mono">Page {page} of {totalPages}</span>
+              <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page >= totalPages} className="btn-secondary text-xs">Next →</button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Auth event log (issue #62) — admin-only
+// ---------------------------------------------------------------------------
+
+const AUTH_EVENT_STYLE: Record<string, string> = {
+  login: 'text-green',
+  logout: 'text-text-muted',
+  login_failed: 'text-amber',
+  login_blocked: 'text-red',
+  lockout: 'text-red',
+  token_created: 'text-cyan',
+  token_revoked: 'text-amber',
+  '2fa_enabled': 'text-green',
+  '2fa_disabled': 'text-amber',
+  user_created: 'text-cyan',
+  user_updated: 'text-cyan',
+  user_deleted: 'text-red',
+}
+
+function AuthEventsHistory() {
+  const [items, setItems] = useState<import('@/api/client').AuthEvent[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const limit = 100
+
+  useEffect(() => {
+    setLoading(true)
+    authApi.events(page, limit)
+      .then(r => { setItems(r.items); setTotal(r.total) })
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [page])
+
+  const totalPages = Math.ceil(total / limit)
+
+  return (
+    <div className="space-y-4">
+      <span className="text-sm text-text-muted font-mono">{total} events</span>
+      {loading ? (
+        <div className="text-center py-12 text-text-muted text-sm">Loading…</div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-12 text-text-muted text-sm">No auth events recorded yet.</div>
+      ) : (
+        <>
+          <div className="card overflow-hidden">
+            <table className="w-full text-xs font-mono">
+              <thead>
+                <tr className="border-b border-border text-text-muted">
+                  <th className="text-left px-3 py-2 font-normal">When</th>
+                  <th className="text-left px-3 py-2 font-normal">Event</th>
+                  <th className="text-left px-3 py-2 font-normal">User</th>
+                  <th className="text-left px-3 py-2 font-normal">Actor</th>
+                  <th className="text-left px-3 py-2 font-normal">IP</th>
+                  <th className="text-left px-3 py-2 font-normal">Detail</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/30">
+                {items.map(e => (
+                  <tr key={e.id} className="hover:bg-surface/50">
+                    <td className="px-3 py-1.5 text-text-muted whitespace-nowrap" title={e.created_at}>{relativeTime(e.created_at)}</td>
+                    <td className={`px-3 py-1.5 ${AUTH_EVENT_STYLE[e.event_type] ?? 'text-text-primary'}`}>{e.event_type}</td>
+                    <td className="px-3 py-1.5 text-text-primary">{e.username ?? '—'}</td>
+                    <td className="px-3 py-1.5 text-text-muted">{e.actor ?? '—'}</td>
+                    <td className="px-3 py-1.5 text-text-muted">{e.ip_address ?? '—'}</td>
+                    <td className="px-3 py-1.5 text-text-muted truncate max-w-xs">{e.detail ?? ''}</td>
+                  </tr>
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
High-impact tier, **security/audit batch (3 bets)**. Stacked on #65 (high-impact part 1), which is stacked on #64 (quick-wins). Base is `feature/roadmap-high-impact`; review #64 → #65 → this in order.

Part of #62 (high-impact tier).

## In this PR

1. **Unified actor attribution + auth-event log** (`6d3b6f7`)
   - `backend/actor.py` ContextVar threads the authenticated username into the SSH audit log and upgrade history (was always `system`). WS handlers + reboot/hold/restart REST endpoints set it; scheduled jobs stay `scheduled`.
   - New **`AuthEventLog`** table records login / login_failed / login_blocked / lockout, token create/revoke, 2FA enable/disable, and user create/update/delete (with actor + IP). `GET /api/auth/events` + an admin-only **"Auth Events"** sub-tab on History.

2. **Login + 2FA brute-force protection** (`6d3b6f7`)
   - Per-(username, ip) lockout after 5 failures in 15 min (15 min lockout) → HTTP 429, a `lockout` auth-event, and a best-effort notification (telegram/slack/webhook).
   - **TOTP replay protection** via `users.totp_last_counter` (rejects a code from an already-used time step).

3. **Enforce maintenance windows as change-control gates** (`b597ae6`)
   - Manual mutating actions now honor deny windows (previously only the scheduled job did): single-server upgrade, bulk upgrade-all (blocked servers skipped with a message), and reboot. Template-apply was already gated in #64.
   - Admins can override per request (`override_window` / `?override_window=true`); the action stays attributed via the audit trail.

## DB
- New table `auth_event_log` (auto-created). New column `users.totp_last_counter` (migration added to `init_db()`).

## Notes / follow-ups
- "allow-only" maintenance-window mode is deferred (this PR enforces the existing deny windows).
- Lockout state is in-memory (resets on restart) — fine for a single-node self-hosted deploy.

## Testing
- ✅ `make ci` (Python syntax + import check + frontend `tsc`/vite) — green.
- ⬜ Runtime verification recommended for: lockout after repeated failures, the Auth Events tab, and window-blocked upgrades/reboots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
