### PR TITLE
feat: novel ideas (5) + self-updating EOL + dependency ordering — #62

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -21,6 +21,10 @@ LOCAL_ZONE = ZoneInfo(TZ)
 # Disabled by default — only enable if you trust all dashboard users.
 ENABLE_TERMINAL = os.getenv("ENABLE_TERMINAL", "false").lower() == "true"
 
+# Only honor X-Forwarded-For (for login lockout / audit IP) when behind a trusted
+# reverse proxy; otherwise a client could spoof the header (issue #62).
+TRUST_PROXY_HEADERS = os.getenv("TRUST_PROXY_HEADERS", "false").lower() == "true"
+
 APP_VERSION = os.getenv("APP_VERSION", "dev")
 
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -223,6 +223,8 @@ async def init_db():
             "ALTER TABLE update_history ADD COLUMN snapshot_name TEXT",
             "ALTER TABLE schedule_config ADD COLUMN snapshot_before_upgrade BOOLEAN DEFAULT 0",
             "ALTER TABLE schedule_config ADD COLUMN canary_health_check BOOLEAN DEFAULT 0",
+            # HTTP hook type (issue #62)
+            "ALTER TABLE upgrade_hooks ADD COLUMN hook_type TEXT DEFAULT 'shell'",
             # api_tokens table is created by Base.metadata.create_all (new table — no migration needed)
             # auth_event_log + fleet_snapshots are new tables — created by create_all, no migration needed
         ]

--- a/backend/database.py
+++ b/backend/database.py
@@ -225,6 +225,8 @@ async def init_db():
             "ALTER TABLE schedule_config ADD COLUMN canary_health_check BOOLEAN DEFAULT 0",
             # HTTP hook type (issue #62)
             "ALTER TABLE upgrade_hooks ADD COLUMN hook_type TEXT DEFAULT 'shell'",
+            # Config drift detection (issue #62)
+            "ALTER TABLE server_stats ADD COLUMN drift_count INTEGER",
             # api_tokens table is created by Base.metadata.create_all (new table — no migration needed)
             # auth_event_log + fleet_snapshots are new tables — created by create_all, no migration needed
         ]

--- a/backend/eol_data.py
+++ b/backend/eol_data.py
@@ -60,6 +60,80 @@ EOL_DATES: dict[str, dict[str, str]] = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# Self-updating overrides (issue #62) — refreshed daily from endoflife.date,
+# cached to disk, and taking precedence over the bundled EOL_DATES fallback.
+# ---------------------------------------------------------------------------
+import json as _json
+import logging as _logging
+import os as _os
+
+_eol_logger = _logging.getLogger(__name__)
+_EOL_OVERRIDES: dict[str, dict[str, str]] = {}
+
+# endoflife.date product id per our os_id (others fall back to the bundled table).
+_EOL_PRODUCTS = {"ubuntu": "ubuntu", "debian": "debian", "proxmox-ve": "proxmox-ve"}
+
+
+def _override_cache_path() -> str:
+    try:
+        from backend.config import DATABASE_PATH
+        return _os.path.join(_os.path.dirname(DATABASE_PATH) or ".", "eol_overrides.json")
+    except Exception:
+        return "eol_overrides.json"
+
+
+def _load_eol_overrides() -> None:
+    try:
+        with open(_override_cache_path()) as fh:
+            data = _json.load(fh)
+        if isinstance(data, dict):
+            _EOL_OVERRIDES.clear()
+            _EOL_OVERRIDES.update({k: v for k, v in data.items() if isinstance(v, dict)})
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        _eol_logger.debug("EOL overrides load failed: %s", exc)
+
+
+async def refresh_eol_data() -> dict[str, int]:
+    """Fetch fresh EOL dates from endoflife.date and cache them. Best-effort;
+    the bundled EOL_DATES remains the fallback for anything not covered."""
+    import httpx
+    new: dict[str, dict[str, str]] = {}
+    async with httpx.AsyncClient(timeout=15) as client:
+        for os_id, product in _EOL_PRODUCTS.items():
+            try:
+                resp = await client.get(f"https://endoflife.date/api/{product}.json")
+                if not resp.is_success:
+                    continue
+                cycles = resp.json()
+                table: dict[str, str] = {}
+                for c in cycles:
+                    cycle = str(c.get("cycle", "")).strip()
+                    eol = c.get("eol")
+                    if cycle and isinstance(eol, str) and len(eol) == 10:  # YYYY-MM-DD
+                        table[cycle] = eol
+                if table:
+                    new[os_id] = table
+            except Exception as exc:
+                _eol_logger.warning("EOL refresh for %s failed: %s", product, exc)
+    if new:
+        _EOL_OVERRIDES.clear()
+        _EOL_OVERRIDES.update(new)
+        try:
+            with open(_override_cache_path(), "w") as fh:
+                _json.dump(new, fh)
+        except Exception as exc:
+            _eol_logger.debug("EOL overrides write failed: %s", exc)
+    counts = {k: len(v) for k, v in new.items()}
+    _eol_logger.info("EOL data refreshed: %s", counts)
+    return counts
+
+
+_load_eol_overrides()
+
+
 # Distros that have an extended-security-maintenance program available
 # (paid Ubuntu Pro for Ubuntu, community LTS for Debian — we only flag Ubuntu
 # here since Debian LTS is out of scope).
@@ -138,10 +212,14 @@ def get_eol_date(os_id: str | None, version_id: str | None) -> date | None:
     """Look up the EOL date for the given OS / version. Returns None if unknown."""
     if not os_id or not version_id:
         return None
-    table = EOL_DATES.get(os_id.lower())
-    if not table:
-        return None
-    iso = table.get(version_id)
+    key = os_id.lower()
+    # Prefer the self-updating overrides (endoflife.date), fall back to the bundled table.
+    iso = (_EOL_OVERRIDES.get(key) or {}).get(version_id)
+    if not iso:
+        table = EOL_DATES.get(key)
+        if not table:
+            return None
+        iso = table.get(version_id)
     if not iso:
         return None
     try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -259,6 +259,7 @@ class ServerStats(Base):
     boot_free_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)        # free MB on /boot (issue #43)
     boot_total_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)       # total MB on /boot
     snapshot_capability: Mapped[str | None] = mapped_column(Text, nullable=True)    # 'btrfs' | 'zfs' | 'container' | 'none' (issue #35)
+    drift_count: Mapped[int | None] = mapped_column(Integer, nullable=True)         # unmerged conffiles (.dpkg-dist/.ucf-dist) (issue #62)
 
     server: Mapped["Server"] = relationship("Server", back_populates="server_stats")
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -76,7 +76,8 @@ class UpgradeHook(Base):
     server_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("servers.id"), nullable=True)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     phase: Mapped[str] = mapped_column(Text, nullable=False)  # 'pre' | 'post'
-    command: Mapped[str] = mapped_column(Text, nullable=False)
+    command: Mapped[str] = mapped_column(Text, nullable=False)  # shell command, OR URL when hook_type='http'
+    hook_type: Mapped[str] = mapped_column(Text, default="shell")  # 'shell' | 'http' (issue #62)
     sort_order: Mapped[int] = mapped_column(Integer, default=0)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=func.now())

--- a/backend/models.py
+++ b/backend/models.py
@@ -452,7 +452,7 @@ class FleetSnapshot(Base):
     __tablename__ = "fleet_snapshots"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    recorded_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), index=True)
+    recorded_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False, index=True)
     total_servers: Mapped[int] = mapped_column(Integer, default=0)
     up_to_date: Mapped[int] = mapped_column(Integer, default=0)
     updates_available: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/notifier.py
+++ b/backend/notifier.py
@@ -234,24 +234,28 @@ async def _send_destination(dest, title: str, body: str | None) -> None:
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             if t == "discord":
-                await client.post(dest.url, json={"content": text[:1900]})
+                resp = await client.post(dest.url, json={"content": text[:1900]})
             elif t == "mattermost":
-                await client.post(dest.url, json={"text": text})
+                resp = await client.post(dest.url, json={"text": text})
             elif t == "ntfy":
-                await client.post(dest.url, data=(body or title).encode("utf-8"),
-                                  headers={"Title": title[:250], "Markdown": "yes"})
+                resp = await client.post(dest.url, data=(body or title).encode("utf-8"),
+                                         headers={"Title": title[:250], "Markdown": "yes"})
             elif t == "pagerduty":
-                await client.post("https://events.pagerduty.com/v2/enqueue", json={
+                resp = await client.post("https://events.pagerduty.com/v2/enqueue", json={
                     "routing_key": dest.url, "event_action": "trigger",
                     "payload": {"summary": title[:1024], "source": "apt-ui", "severity": "warning",
                                 "custom_details": {"body": body or ""}},
                 })
             elif t == "opsgenie":
-                await client.post("https://api.opsgenie.com/v2/alerts",
-                                  headers={"Authorization": f"GenieKey {dest.url}"},
-                                  json={"message": title[:130], "description": body or ""})
+                resp = await client.post("https://api.opsgenie.com/v2/alerts",
+                                         headers={"Authorization": f"GenieKey {dest.url}"},
+                                         json={"message": title[:130], "description": body or ""})
             else:  # generic webhook
-                await client.post(dest.url, json={"title": title, "body": body, "source": "apt-ui"})
+                resp = await client.post(dest.url, json={"title": title, "body": body, "source": "apt-ui"})
+        # httpx doesn't raise on 4xx/5xx — many integrations fail this way; log it.
+        if not resp.is_success:
+            logger.warning("notification destination %s (%s) returned HTTP %s: %s",
+                           getattr(dest, "name", "?"), t, resp.status_code, resp.text[:200])
     except Exception as exc:
         logger.warning("notification destination %s (%s) failed: %s", getattr(dest, "name", "?"), t, exc)
 

--- a/backend/routers/api_v1.py
+++ b/backend/routers/api_v1.py
@@ -89,6 +89,8 @@ async def v1_upgrade(server_id: int, body: dict | None = None,
         raise HTTPException(status_code=409, detail=f"Upgrade {block}")
 
     action = body.get("action", "upgrade")
+    if action not in ("upgrade", "dist-upgrade"):
+        raise HTTPException(status_code=400, detail="action must be 'upgrade' or 'dist-upgrade'")
     allow_phased = bool(body.get("allow_phased", False))
     actor = user.username
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -40,9 +40,13 @@ _locked_until: dict[tuple[str, str], float] = {}
 def _client_ip(request: Request | None) -> str:
     if request is None:
         return "unknown"
-    fwd = request.headers.get("x-forwarded-for")
-    if fwd:
-        return fwd.split(",")[0].strip()
+    # Trust X-Forwarded-For only when explicitly configured behind a proxy, else a
+    # client can spoof it to dodge lockout / pollute the audit trail.
+    from backend.config import TRUST_PROXY_HEADERS
+    if TRUST_PROXY_HEADERS:
+        fwd = request.headers.get("x-forwarded-for")
+        if fwd:
+            return fwd.split(",")[0].strip()
     return request.client.host if request.client else "unknown"
 
 
@@ -168,11 +172,18 @@ async def login(
                     await _alert_lockout(body.username, ip)
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid 2FA code")
             # Replay protection: reject a code from a TOTP step already used to log in.
-            counter = int(time.time()) // 30
-            if user.totp_last_counter is not None and counter <= user.totp_last_counter:
+            # Use the step that actually matched (within valid_window=1) so accepting a
+            # previous-step code doesn't wrongly reject the next current-step code.
+            now = int(time.time())
+            matched = now // 30
+            for delta in (0, -1, 1):
+                if totp.at(now + delta * 30) == code:
+                    matched = (now // 30) + delta
+                    break
+            if user.totp_last_counter is not None and matched <= user.totp_last_counter:
                 raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
                                     detail="2FA code already used; wait for the next code")
-            user.totp_last_counter = counter
+            user.totp_last_counter = matched
         except HTTPException:
             raise
         except Exception:
@@ -280,6 +291,10 @@ async def create_token(
     if isinstance(raw_scopes, str):
         raw_scopes = [s.strip() for s in raw_scopes.split(",") if s.strip()]
     scopes = [s for s in raw_scopes if s in ALL_SCOPES]
+    # If the caller asked for scopes but none were valid, fail loudly rather than
+    # silently minting a full-access (unscoped) token.
+    if raw_scopes and not scopes:
+        raise HTTPException(status_code=400, detail=f"No valid scopes. Allowed: {', '.join(ALL_SCOPES)}")
     expires_at = None
     days = body.get("expires_days")
     if isinstance(days, (int, float)) and days > 0:

--- a/backend/routers/hooks.py
+++ b/backend/routers/hooks.py
@@ -28,6 +28,7 @@ def _serialize(h: UpgradeHook) -> dict:
         "name": h.name,
         "phase": h.phase,
         "command": h.command,
+        "hook_type": getattr(h, "hook_type", "shell"),
         "sort_order": h.sort_order,
         "enabled": h.enabled,
         "created_at": h.created_at,
@@ -61,11 +62,15 @@ async def create_hook(
         if srv is None:
             raise HTTPException(status_code=404, detail="Server not found")
 
+    hook_type = (body.get("hook_type") or "shell").strip()
+    if hook_type not in ("shell", "http"):
+        hook_type = "shell"
     h = UpgradeHook(
         server_id=sid,
         name=name,
         phase=phase,
         command=command,
+        hook_type=hook_type,
         sort_order=int(body.get("sort_order", 0)),
         enabled=bool(body.get("enabled", True)),
     )
@@ -92,6 +97,8 @@ async def update_hook(
         h.phase = body["phase"]
     if "command" in body and body["command"]:
         h.command = body["command"]
+    if "hook_type" in body and body["hook_type"] in ("shell", "http"):
+        h.hook_type = body["hook_type"]
     if "sort_order" in body:
         h.sort_order = int(body["sort_order"])
     if "enabled" in body:

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -202,7 +202,8 @@ def _dest_dict(d) -> dict:
 
 
 @router.get("/destinations")
-async def list_destinations(_: User = Depends(get_current_user), db: AsyncSession = Depends(get_db)):
+async def list_destinations(_: User = Depends(require_admin), db: AsyncSession = Depends(get_db)):
+    # Admin-only: the rows contain webhook URLs / routing keys / API keys.
     from backend.models import NotificationDestination
     res = await db.execute(select(NotificationDestination).order_by(NotificationDestination.name))
     return [_dest_dict(d) for d in res.scalars().all()]
@@ -231,9 +232,25 @@ async def update_destination(dest_id: int, body: dict, _: User = Depends(require
     d = (await db.execute(select(NotificationDestination).where(NotificationDestination.id == dest_id))).scalar_one_or_none()
     if d is None:
         raise HTTPException(status_code=404, detail="Destination not found")
-    for f in ("name", "type", "url", "events", "enabled"):
-        if f in body:
-            setattr(d, f, body[f])
+    if "type" in body:
+        t = (body.get("type") or "").strip().lower()
+        if t not in _DEST_TYPES:
+            raise HTTPException(status_code=400, detail="Invalid destination type")
+        d.type = t
+    if "name" in body:
+        name = (body.get("name") or "").strip()
+        if not name:
+            raise HTTPException(status_code=400, detail="name cannot be empty")
+        d.name = name
+    if "url" in body:
+        url = (body.get("url") or "").strip()
+        if not url:
+            raise HTTPException(status_code=400, detail="url cannot be empty")
+        d.url = url
+    if "events" in body:
+        d.events = (body.get("events") or "").strip() or None
+    if "enabled" in body:
+        d.enabled = bool(body["enabled"])
     await db.commit()
     await db.refresh(d)
     return _dest_dict(d)

--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -5,9 +5,12 @@ Canned queries that aggregate UpdateCheck and UpdateHistory data for audit/SLA
 reporting. Exposed as JSON; the frontend offers CSV download.
 """
 
+import csv as _csv
+import io as _io
+import json as _json
 from datetime import datetime, timedelta
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -220,3 +223,60 @@ async def security_sla(
         },
         "servers": rows,
     }
+
+
+@router.get("/change-record")
+async def change_record(
+    days: int = Query(default=7, ge=1, le=365),
+    fmt: str = Query(default="md", pattern="^(md|csv)$"),
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Exportable patch/change record (issue #62): every upgrade in the window as a
+    Markdown or CSV change ticket (server, action, packages, status, who, snapshot)."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    srv_map = {s.id: s.name for s in (await db.execute(select(Server))).scalars().all()}
+    rows = (await db.execute(
+        select(UpdateHistory).where(UpdateHistory.started_at >= cutoff).order_by(UpdateHistory.started_at.desc())
+    )).scalars().all()
+
+    def _pkgcount(h) -> int:
+        if not h.packages_upgraded:
+            return 0
+        try:
+            return len(_json.loads(h.packages_upgraded))
+        except Exception:
+            return 0
+
+    records = [
+        {
+            "started_at": h.started_at.isoformat() if h.started_at else "",
+            "server": srv_map.get(h.server_id, f"#{h.server_id}"),
+            "action": h.action,
+            "status": h.status,
+            "packages": _pkgcount(h),
+            "initiated_by": h.initiated_by,
+            "snapshot": h.snapshot_name or "",
+        }
+        for h in rows
+    ]
+
+    if fmt == "csv":
+        buf = _io.StringIO()
+        w = _csv.writer(buf)
+        w.writerow(["started_at", "server", "action", "status", "packages", "initiated_by", "snapshot"])
+        for r in records:
+            w.writerow([r["started_at"], r["server"], r["action"], r["status"], r["packages"], r["initiated_by"], r["snapshot"]])
+        return Response(content=buf.getvalue(), media_type="text/csv",
+                        headers={"Content-Disposition": f"attachment; filename=change-record-{days}d.csv"})
+
+    # Markdown
+    lines = [f"# apt-ui change record — last {days} days", "",
+             f"Generated {datetime.utcnow().isoformat()}Z · {len(records)} upgrade events", "",
+             "| When | Server | Action | Status | Pkgs | By | Snapshot |",
+             "|---|---|---|---|---|---|---|"]
+    for r in records:
+        lines.append(f"| {r['started_at']} | {r['server']} | {r['action']} | {r['status']} | "
+                     f"{r['packages']} | {r['initiated_by']} | {r['snapshot']} |")
+    return Response(content="\n".join(lines), media_type="text/markdown",
+                    headers={"Content-Disposition": f"attachment; filename=change-record-{days}d.md"})

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -1015,6 +1015,63 @@ async def upgrade_impact(
     }
 
 
+_FLEET_CMD_ALLOWLIST = {
+    "uptime", "uname -a", "hostnamectl", "df -h", "free -h", "who", "last -n 5",
+    "cat /etc/os-release", "systemctl --failed", "dpkg --audit",
+    "ls -1 /var/run/reboot-required.pkgs", "lsb_release -a",
+}
+
+
+@router.post("/run-command")
+async def fleet_run_command(
+    body: dict,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(require_admin),
+):
+    """Run a command across selected servers and group identical outputs (issue #62).
+
+    Only allowlisted read-only commands are permitted unless ENABLE_TERMINAL is set
+    (raw mode — admin only). Every execution is recorded in the SSH audit log."""
+    import asyncio as _asyncio
+    from backend.config import ENABLE_TERMINAL
+    set_actor(user.username)
+    server_ids = body.get("server_ids") or []
+    command = (body.get("command") or "").strip()
+    if not command:
+        raise HTTPException(status_code=400, detail="command required")
+    if command not in _FLEET_CMD_ALLOWLIST and not ENABLE_TERMINAL:
+        raise HTTPException(status_code=400,
+                            detail="Command not allowlisted (set ENABLE_TERMINAL=true to allow raw commands)")
+    if not server_ids:
+        raise HTTPException(status_code=400, detail="server_ids required")
+
+    res = await db.execute(select(Server).where(Server.id.in_(server_ids), Server.is_enabled == True))
+    servers = res.scalars().all()
+
+    sem = _asyncio.Semaphore(5)
+
+    async def _run_one(s: Server):
+        async with sem:
+            try:
+                r = await run_command(s, command, timeout=30)
+                out = (r.stdout or "") + (("\n" + r.stderr) if r.stderr else "")
+                return s.name, out.strip(), r.exit_code
+            except Exception as exc:
+                return s.name, f"error: {exc}", 255
+
+    pairs = await _asyncio.gather(*[_run_one(s) for s in servers])
+
+    # Group servers by identical output ("47 said X, 3 said Y").
+    groups: dict[str, list[str]] = {}
+    for name, out, _ec in pairs:
+        groups.setdefault(out, []).append(name)
+    grouped = [
+        {"output": out, "servers": sorted(names), "count": len(names)}
+        for out, names in sorted(groups.items(), key=lambda kv: -len(kv[1]))
+    ]
+    return {"command": command, "grouped": grouped}
+
+
 @router.post("/bulk-hold")
 async def bulk_hold(
     body: dict,

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -979,6 +979,42 @@ async def get_server_health(
     }
 
 
+@router.get("/{server_id}/impact")
+async def upgrade_impact(
+    server_id: int,
+    db: AsyncSession = Depends(get_db),
+    _: User = Depends(get_current_user),
+):
+    """Upgrade impact preview (issue #62): use needrestart to show which services
+    would restart and whether a reboot is truly required (vs the frontend's regex)."""
+    server = await _get_server_or_404(server_id, db)
+    sudo = "" if server.username == "root" else "sudo "
+    chk = await run_command(server, "command -v needrestart", timeout=15)
+    if chk.exit_code != 0:
+        return {"available": False, "detail": "needrestart is not installed on this server"}
+    res = await run_command(server, f"{sudo}needrestart -b 2>/dev/null", timeout=60)
+    ksta = kcur = kexp = None
+    services: list[str] = []
+    for line in (res.stdout or "").splitlines():
+        if line.startswith("NEEDRESTART-KSTA:"):
+            ksta = line.split(":", 1)[1].strip()
+        elif line.startswith("NEEDRESTART-KCUR:"):
+            kcur = line.split(":", 1)[1].strip()
+        elif line.startswith("NEEDRESTART-KEXP:"):
+            kexp = line.split(":", 1)[1].strip()
+        elif line.startswith("NEEDRESTART-SVC:"):
+            services.append(line.split(":", 1)[1].strip())
+    return {
+        "available": True,
+        # KSTA: 1=kernel current, 2=ABI-compatible upgrade pending, 3=reboot required
+        "reboot_required": ksta == "3",
+        "kernel_status": ksta,
+        "kernel_current": kcur,
+        "kernel_expected": kexp,
+        "services": sorted(set(services)),
+    }
+
+
 @router.post("/bulk-hold")
 async def bulk_hold(
     body: dict,

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -275,6 +275,7 @@ async def _build_server_out(
         boot_free_mb=stats_row.boot_free_mb if stats_row else None,
         boot_total_mb=stats_row.boot_total_mb if stats_row else None,
         snapshot_capability=stats_row.snapshot_capability if stats_row else None,
+        drift_count=stats_row.drift_count if stats_row else None,
         os_eol_date=eol["date"],
         os_eol_days_remaining=eol["days_remaining"],
         os_eol_severity=eol["severity"],

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -670,6 +670,17 @@ async def rollback_snapshot_endpoint(
     snap = (body.get("snapshot") or "").strip()
     if not snap:
         raise HTTPException(status_code=400, detail="snapshot name required")
+    # Only allow restoring a snapshot apt-ui actually recorded for THIS server, so a
+    # typo / arbitrary name can't roll the box back to an unrelated restore point.
+    from backend.models import UpdateHistory
+    known = (await db.execute(
+        select(UpdateHistory.id).where(
+            UpdateHistory.server_id == server_id,
+            UpdateHistory.snapshot_name == snap,
+        ).limit(1)
+    )).scalar_one_or_none()
+    if known is None:
+        raise HTTPException(status_code=400, detail="Unknown snapshot for this server")
     from backend.upgrade_manager import restore_snapshot
     try:
         result = await restore_snapshot(server, snap)
@@ -992,7 +1003,10 @@ async def upgrade_impact(
     chk = await run_command(server, "command -v needrestart", timeout=15)
     if chk.exit_code != 0:
         return {"available": False, "detail": "needrestart is not installed on this server"}
-    res = await run_command(server, f"{sudo}needrestart -b 2>/dev/null", timeout=60)
+    res = await run_command(server, f"{sudo}needrestart -b", timeout=60)
+    if res.exit_code != 0 or "NEEDRESTART-" not in (res.stdout or ""):
+        detail = (res.stderr or res.stdout or "needrestart produced no output").strip()
+        return {"available": False, "detail": detail[:300]}
     ksta = kcur = kexp = None
     services: list[str] = []
     for line in (res.stdout or "").splitlines():
@@ -1048,7 +1062,9 @@ async def fleet_run_command(
     res = await db.execute(select(Server).where(Server.id.in_(server_ids), Server.is_enabled == True))
     servers = res.scalars().all()
 
-    sem = _asyncio.Semaphore(5)
+    from backend.models import ScheduleConfig
+    cfg = (await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))).scalar_one_or_none()
+    sem = _asyncio.Semaphore(max(1, cfg.upgrade_concurrency if cfg else 5))
 
     async def _run_one(s: Server):
         async with sem:

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -94,7 +94,7 @@ async def fleet_trend(
     return {
         "points": [
             {
-                "recorded_at": r.recorded_at.isoformat() if r.recorded_at else None,
+                "recorded_at": (r.recorded_at or datetime.utcnow()).isoformat(),
                 "total_servers": r.total_servers,
                 "up_to_date": r.up_to_date,
                 "updates_available": r.updates_available,

--- a/backend/routers/upgrades.py
+++ b/backend/routers/upgrades.py
@@ -880,7 +880,7 @@ async def ws_upgrade_all(websocket: WebSocket):
             block = await window_block_reason(db, s.id, override=override_window)
             if block:
                 try:
-                    await websocket.send_json({"type": "error", "server_id": s.id, "server_name": s.name,
+                    await websocket.send_json({"type": "skipped", "server_id": s.id, "server_name": s.name,
                                                "data": f"Skipped — {block}."})
                 except Exception:
                     pass
@@ -914,7 +914,7 @@ async def ws_upgrade_all(websocket: WebSocket):
                 histories.append((server, h))
 
     try:
-        await asyncio.gather(*[_do_tracked(s) for s in to_upgrade])
+        await asyncio.gather(*[_do_tracked(s) for s in to_upgrade], return_exceptions=True)
     except WebSocketDisconnect:
         pass
     finally:
@@ -1121,7 +1121,19 @@ async def ws_template_apply(websocket: WebSocket, template_id: int):
             async with AsyncSessionLocal() as wdb:
                 window = await get_active_window_for_server(wdb, server.id)
             if window is not None:
-                await send_fn({"type": "error", "data": f"Skipped — in maintenance window '{window.name}'"})
+                await send_fn({"type": "skipped", "data": f"Skipped — in maintenance window '{window.name}'"})
+                # Record the skip in history so it's visible/auditable.
+                try:
+                    async with AsyncSessionLocal() as sdb:
+                        sdb.add(UpdateHistory(
+                            server_id=server.id, status="skipped",
+                            action=f"template:{template_name}", initiated_by=actor,
+                            completed_at=datetime.utcnow(),
+                            log_output=f"Skipped — in maintenance window '{window.name}'",
+                        ))
+                        await sdb.commit()
+                except Exception:
+                    pass
                 return
 
             sudo = "" if server.username == "root" else "sudo "
@@ -1165,7 +1177,7 @@ async def ws_template_apply(websocket: WebSocket, template_id: int):
                         pass
 
     try:
-        await asyncio.gather(*[_apply_to_server(s) for s in servers])
+        await asyncio.gather(*[_apply_to_server(s) for s in servers], return_exceptions=True)
     except WebSocketDisconnect:
         pass
     finally:

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -512,6 +512,15 @@ async def configure_jobs():
         replace_existing=True,
     )
 
+    # Daily EOL data refresh from endoflife.date (issue #62)
+    from backend.eol_data import refresh_eol_data
+    _scheduler.add_job(
+        refresh_eol_data,
+        CronTrigger(hour=4, minute=30, timezone=TZ),
+        id="eol_refresh",
+        replace_existing=True,
+    )
+
 
 def _remove_jobs():
     for job_id in ("check_all", "auto_upgrade", "weekly_digest"):
@@ -564,6 +573,17 @@ async def start_scheduler():
     if not _scheduler.running:
         _scheduler.start()
     logger.info("Scheduler started")
+    # Kick a one-time EOL data refresh shortly after boot (best-effort, non-blocking).
+    import asyncio as _asyncio
+
+    async def _initial_eol_refresh():
+        try:
+            from backend.eol_data import refresh_eol_data
+            await refresh_eol_data()
+        except Exception as exc:
+            logger.debug("initial EOL refresh failed: %s", exc)
+
+    _asyncio.create_task(_initial_eol_refresh())
 
 
 def stop_scheduler():

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -121,21 +121,32 @@ async def _job_auto_upgrade():
         if skipped_for_maintenance:
             logger.info("Auto-upgrade: skipped %d server(s) inside maintenance windows", skipped_for_maintenance)
 
-        # Group by ring tag for staged rollout (issue #41)
+        # Group by ring tag for staged rollout (issue #41), and within each ring sort
+        # by an optional order:N tag (lower first) so dependency-ordered hosts — e.g. a
+        # DB replica before its primary, or HA members one at a time — patch in a safe
+        # sequence (issue #62). Servers without order:N default to 100.
         rings: dict[str, list[Server]] = {}
         if staged:
             from backend.models import Tag, ServerTag
             from sqlalchemy import select as _sel
+            order_of: dict[int, int] = {}
             for s in to_upgrade:
                 tag_res = await db.execute(
                     _sel(Tag.name)
                     .join(ServerTag, ServerTag.tag_id == Tag.id)
-                    .where(ServerTag.server_id == s.id, Tag.name.like("ring:%"))
+                    .where(ServerTag.server_id == s.id, Tag.name.like("ring:%") | Tag.name.like("order:%"))
                 )
-                ring_tags = [r for (r,) in tag_res.all()]
-                # Use the first matching ring tag, or "default" if none
+                names = [r for (r,) in tag_res.all()]
+                ring_tags = [n for n in names if n.startswith("ring:")]
+                order_tags = [n for n in names if n.startswith("order:")]
                 ring = ring_tags[0] if ring_tags else "ring:default"
+                try:
+                    order_of[s.id] = int(order_tags[0].split(":", 1)[1]) if order_tags else 100
+                except (ValueError, IndexError):
+                    order_of[s.id] = 100
                 rings.setdefault(ring, []).append(s)
+            for ring_name in rings:
+                rings[ring_name].sort(key=lambda srv: (order_of.get(srv.id, 100), srv.name))
         else:
             rings = {"all": to_upgrade}
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -40,6 +40,8 @@ def get_next_run_time(job_id: str) -> datetime | None:
 
 async def _job_check_all():
     logger.info("Scheduler: running scheduled check-all")
+    from backend.actor import set_actor
+    set_actor("scheduled")
     from backend.database import AsyncSessionLocal
     from backend.models import Server, ScheduleConfig
     from backend.update_checker import check_all_servers
@@ -79,6 +81,8 @@ async def _job_check_all():
 
 async def _job_auto_upgrade():
     logger.info("Scheduler: running auto-upgrade")
+    from backend.actor import set_actor
+    set_actor("scheduled")
     from backend.database import AsyncSessionLocal
     from backend.models import Server, ScheduleConfig, UpdateCheck
     from backend.upgrade_manager import upgrade_server
@@ -164,8 +168,8 @@ async def _job_auto_upgrade():
                     initiated_by="scheduled",
                 )
 
-    async def _health_ok(server) -> tuple[bool, str]:
-        """Post-upgrade health probe: any failed systemd units = degraded."""
+    async def _failed_units(server) -> set[str]:
+        """Return the set of failed systemd units (empty if the probe is unavailable)."""
         from backend.ssh_manager import run_command
         sudo = "" if server.username == "root" else "sudo "
         res = await run_command(
@@ -173,12 +177,9 @@ async def _job_auto_upgrade():
             f"{sudo}systemctl list-units --state=failed --no-legend --plain 2>/dev/null | awk '{{print $1}}'",
             timeout=30,
         )
-        if res.exit_code not in (0,):
-            return True, "health probe unavailable"  # don't block the rollout on a probe error
-        failed = [ln.strip() for ln in (res.stdout or "").splitlines() if ln.strip()]
-        if failed:
-            return False, f"{len(failed)} failed unit(s): {', '.join(failed[:5])}"
-        return True, "ok"
+        if res.exit_code != 0:
+            return set()  # probe unavailable — don't manufacture a degradation
+        return {ln.strip() for ln in (res.stdout or "").splitlines() if ln.strip()}
 
     if not staged:
         await asyncio.gather(*[_do(s) for s in to_upgrade])
@@ -191,14 +192,20 @@ async def _job_auto_upgrade():
     for i, ring_name in enumerate(ring_names):
         ring_servers = rings[ring_name]
         logger.info("Staged rollout: starting %s (%d servers)", ring_name, len(ring_servers))
+        # Capture a pre-upgrade baseline of failed units so the canary aborts only on
+        # NEW degradation, not on units that were already failing.
+        baseline: dict[int, set[str]] = {}
+        if canary:
+            for s in ring_servers:
+                baseline[s.id] = await _failed_units(s)
         if canary and len(ring_servers) > 1:
-            # Canary: upgrade the first server, verify its health, then promote the rest.
+            # Canary: upgrade the first server, verify no new failures, then promote the rest.
             canary_srv, rest = ring_servers[0], ring_servers[1:]
             await _do(canary_srv)
-            ok, summary = await _health_ok(canary_srv)
-            if not ok:
-                logger.error("Canary %s failed health (%s); aborting %s and further rings",
-                             canary_srv.name, summary, ring_name)
+            new = await _failed_units(canary_srv) - baseline.get(canary_srv.id, set())
+            if new:
+                logger.error("Canary %s degraded (new failed units: %s); aborting %s and further rings",
+                             canary_srv.name, ", ".join(sorted(new)), ring_name)
                 return
             await asyncio.gather(*[_do(s) for s in rest])
         else:
@@ -227,13 +234,14 @@ async def _job_auto_upgrade():
                     )
                     return
 
-        # Health-verify the whole ring before promoting (success != just apt exit code).
+        # Health-verify the whole ring before promoting — abort only on NEW failed
+        # units vs the pre-upgrade baseline (success != just apt exit code).
         if canary:
             for s in ring_servers:
-                ok, summary = await _health_ok(s)
-                if not ok:
-                    logger.error("Staged rollout: %s unhealthy after upgrade (%s); aborting promotion",
-                                 s.name, summary)
+                new = await _failed_units(s) - baseline.get(s.id, set())
+                if new:
+                    logger.error("Staged rollout: %s degraded after upgrade (new failed units: %s); aborting promotion",
+                                 s.name, ", ".join(sorted(new)))
                     return
 
         # If not the last ring, wait the configured delay before promoting

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -179,6 +179,7 @@ class ServerOut(BaseModel):
     boot_free_mb: Optional[int] = None              # free MB on /boot (issue #43)
     boot_total_mb: Optional[int] = None             # total MB on /boot
     snapshot_capability: Optional[str] = None       # 'btrfs' | 'zfs' | 'container' | 'none' (issue #35)
+    drift_count: Optional[int] = None                # unmerged conffiles (issue #62)
     os_eol_date: Optional[str] = None                # ISO date string of OS EOL (issue #57)
     os_eol_days_remaining: Optional[int] = None      # negative when past EOL
     os_eol_severity: Optional[str] = None            # 'ok' | 'warning' | 'alert' | 'expired' | 'unknown'

--- a/backend/update_checker.py
+++ b/backend/update_checker.py
@@ -178,6 +178,13 @@ async def _gather_stats(server: Server) -> dict:
             "elif [ -f /.dockerenv ] || systemd-detect-virt 2>/dev/null | grep -qE '^(lxc|docker)$'; then echo container; "
             "else echo none; fi"
         ),
+        # Config drift (issue #62) — count unmerged conffiles left by past upgrades.
+        # These (.dpkg-dist/.ucf-dist/.dpkg-new under /etc) are the most common
+        # post-patch breakage cause and are cheap to count.
+        "drift": (
+            "find /etc \\( -name '*.dpkg-dist' -o -name '*.ucf-dist' -o -name '*.dpkg-new' \\) "
+            "2>/dev/null | wc -l"
+        ),
         # /boot disk usage (separate partition on most distros — kernel buildup fills it)
         "boot_disk": "df -P -BM /boot 2>/dev/null | awk 'NR==2{gsub(\"M\",\"\",$2); gsub(\"M\",\"\",$4); print $2\" \"$4}' || echo ''",
         # Detect apt HTTP proxy (apt-cacher-ng or similar).
@@ -352,6 +359,11 @@ async def _gather_stats(server: Server) -> dict:
     if snapshot_capability not in ("btrfs", "zfs", "container", "none"):
         snapshot_capability = None
 
+    drift_raw = results.get("drift")
+    drift_count = None
+    if drift_raw and drift_raw.stdout.strip().isdigit():
+        drift_count = int(drift_raw.stdout.strip())
+
     return {
         "uptime_seconds": uptime_seconds,
         "kernel_version": kernel_version,
@@ -372,6 +384,7 @@ async def _gather_stats(server: Server) -> dict:
         "boot_total_mb": boot_total_mb,
         "boot_free_mb": boot_free_mb,
         "snapshot_capability": snapshot_capability,
+        "drift_count": drift_count,
     }
 
 
@@ -560,6 +573,7 @@ async def check_server(
         boot_total_mb=stats.get("boot_total_mb"),
         boot_free_mb=stats.get("boot_free_mb"),
         snapshot_capability=stats.get("snapshot_capability"),
+        drift_count=stats.get("drift_count"),
     )
     db.add(stat_row)
 

--- a/backend/upgrade_manager.py
+++ b/backend/upgrade_manager.py
@@ -75,7 +75,8 @@ async def _run_hook(server: Server, hook, send_fn) -> int:
             if send_fn:
                 await send_fn({"type": "output", "data": f"  http hook '{hook.name}': invalid URL\n"})
             return 1
-        if parsed.hostname in ("169.254.169.254", "metadata.google.internal"):
+        host_norm = parsed.hostname.rstrip(".").lower()
+        if host_norm in ("169.254.169.254", "metadata.google.internal"):
             if send_fn:
                 await send_fn({"type": "output", "data": f"  http hook '{hook.name}': blocked metadata endpoint\n"})
             return 1

--- a/backend/upgrade_manager.py
+++ b/backend/upgrade_manager.py
@@ -59,6 +59,43 @@ async def _load_hooks(server_id: int, phase: str, db: AsyncSession):
     return list(res.scalars().all())
 
 
+async def _run_hook(server: Server, hook, send_fn) -> int:
+    """Execute a pre/post hook. Returns an exit code (0 = success).
+
+    'shell' hooks run over SSH (default). 'http' hooks POST a small JSON payload to
+    the URL in hook.command — useful for draining a load balancer or silencing alerts
+    from apt-ui itself (the box being patched is about to reboot). issue #62.
+    """
+    if getattr(hook, "hook_type", "shell") == "http":
+        import httpx
+        from urllib.parse import urlparse
+        url = (hook.command or "").strip()
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            if send_fn:
+                await send_fn({"type": "output", "data": f"  http hook '{hook.name}': invalid URL\n"})
+            return 1
+        if parsed.hostname in ("169.254.169.254", "metadata.google.internal"):
+            if send_fn:
+                await send_fn({"type": "output", "data": f"  http hook '{hook.name}': blocked metadata endpoint\n"})
+            return 1
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.post(url, json={
+                    "hook": hook.name, "phase": hook.phase,
+                    "server": server.name, "hostname": server.hostname,
+                })
+            if send_fn:
+                await send_fn({"type": "output", "data": f"  http hook '{hook.name}' → {resp.status_code}\n"})
+            return 0 if resp.is_success else 1
+        except Exception as exc:
+            if send_fn:
+                await send_fn({"type": "output", "data": f"  http hook '{hook.name}' failed: {exc}\n"})
+            return 1
+    hr = await run_command_stream(server, hook.command, send_fn, timeout=600)
+    return hr.exit_code
+
+
 def _validate_package_names(packages: list[str]) -> list[str]:
     """Return *packages* unchanged if all names are valid; raise ValueError otherwise.
 
@@ -165,9 +202,9 @@ async def upgrade_server(
                     for hook in pre_hooks:
                         if send_fn:
                             await send_fn({"type": "output", "data": f"\n→ pre-hook: {hook.name}\n"})
-                        hr = await run_command_stream(server, hook.command, _send, timeout=600)
-                        if hr.exit_code != 0:
-                            raise RuntimeError(f"Pre-hook '{hook.name}' failed (exit {hr.exit_code}); aborting upgrade")
+                        rc = await _run_hook(server, hook, _send)
+                        if rc != 0:
+                            raise RuntimeError(f"Pre-hook '{hook.name}' failed (exit {rc}); aborting upgrade")
 
                 # Step 0.5: pre-upgrade snapshot (issue #62) — timeshift restore point
                 _cfg = (await db.execute(select(ScheduleConfig).where(ScheduleConfig.id == 1))).scalar_one_or_none()
@@ -248,7 +285,7 @@ async def upgrade_server(
                         if send_fn:
                             await send_fn({"type": "output", "data": f"\n→ post-hook: {hook.name}\n"})
                         try:
-                            await run_command_stream(server, hook.command, _send, timeout=600)
+                            await _run_hook(server, hook, _send)
                         except Exception as hexc:
                             logger.warning("Post-hook '%s' on %s raised: %s", hook.name, server.name, hexc)
                             if send_fn:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import Compare from '@/pages/Compare'
 import Search from '@/pages/Search'
 import Reports from '@/pages/Reports'
 import Security from '@/pages/Security'
+import Run from '@/pages/Run'
 
 // Keyed by :id so navigating between servers (e.g. via the command palette) fully
 // remounts ServerDetail and all its tab children. Without this, react-router reuses
@@ -121,6 +122,16 @@ export default function App() {
             <RequireAuth>
               <Layout>
                 <Security />
+              </Layout>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/run"
+          element={
+            <RequireAuth>
+              <Layout>
+                <Run />
               </Layout>
             </RequireAuth>
           }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -171,6 +171,7 @@ export const servers = {
   remove: (id: number) => del(`/api/servers/${id}`),
   reboot: (id: number) => post<{ success: boolean; detail: string }>(`/api/servers/${id}/reboot`),
   rollback: (id: number, snapshot: string) => post<{ success: boolean; detail: string }>(`/api/servers/${id}/rollback`, { snapshot }),
+  impact: (id: number) => get<{ available: boolean; detail?: string; reboot_required?: boolean; kernel_current?: string | null; kernel_expected?: string | null; services?: string[] }>(`/api/servers/${id}/impact`),
   test: (id: number) => post<{ success: boolean; detail: string }>(`/api/servers/${id}/test`),
   reachability: () => get<Record<string, boolean>>('/api/servers/reachability'),
   check: (id: number) => post<{ status: string; packages_available: number }>(`/api/servers/${id}/check`),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -172,6 +172,10 @@ export const servers = {
   reboot: (id: number) => post<{ success: boolean; detail: string }>(`/api/servers/${id}/reboot`),
   rollback: (id: number, snapshot: string) => post<{ success: boolean; detail: string }>(`/api/servers/${id}/rollback`, { snapshot }),
   impact: (id: number) => get<{ available: boolean; detail?: string; reboot_required?: boolean; kernel_current?: string | null; kernel_expected?: string | null; services?: string[] }>(`/api/servers/${id}/impact`),
+  runCommand: (server_ids: number[], command: string) =>
+    post<{ command: string; grouped: { output: string; servers: string[]; count: number }[] }>(
+      '/api/servers/run-command', { server_ids, command }
+    ),
   test: (id: number) => post<{ success: boolean; detail: string }>(`/api/servers/${id}/test`),
   reachability: () => get<Record<string, boolean>>('/api/servers/reachability'),
   check: (id: number) => post<{ status: string; packages_available: number }>(`/api/servers/${id}/check`),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -461,6 +461,7 @@ export interface UpgradeHook {
   name: string
   phase: 'pre' | 'post'
   command: string
+  hook_type: 'shell' | 'http'
   sort_order: number
   enabled: boolean
   created_at: string

--- a/frontend/src/components/ConfirmHost.tsx
+++ b/frontend/src/components/ConfirmHost.tsx
@@ -27,6 +27,7 @@ export default function ConfirmHost() {
         onClick={e => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        aria-label={pending.title || 'Confirm'}
       >
         {pending.title && <h3 className="font-mono text-text-primary">{pending.title}</h3>}
         <p className="text-sm text-text-muted whitespace-pre-line">{pending.message}</p>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -162,7 +162,8 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       badgeColor: 'bg-red/20 text-red border-red/40',
     },
     { to: '/reports', label: 'Reports' },
-    { to: '/run', label: 'Run' },
+    // Run page calls an admin-only endpoint — only surface it to admins.
+    ...(user?.is_admin ? [{ to: '/run', label: 'Run' }] : []),
   ]
 
   return (

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -162,6 +162,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
       badgeColor: 'bg-red/20 text-red border-red/40',
     },
     { to: '/reports', label: 'Reports' },
+    { to: '/run', label: 'Run' },
   ]
 
   return (

--- a/frontend/src/components/NotificationDestinations.tsx
+++ b/frontend/src/components/NotificationDestinations.tsx
@@ -32,22 +32,22 @@ export default function NotificationDestinations() {
       setForm({ name: '', type: 'discord', url: '', events: '' })
       load()
       toast.success('Destination added')
-    } catch (err) { toast.error((err as Error).message) }
+    } catch (err) { toast.error(err instanceof Error ? err.message : String(err)) }
     finally { setSaving(false) }
   }
 
   async function remove(d: NotificationDestination) {
     if (!await confirmDialog({ message: `Delete destination "${d.name}"?`, confirmLabel: 'Delete', danger: true })) return
-    try { await notifApi.deleteDestination(d.id); load() } catch (err) { toast.error((err as Error).message) }
+    try { await notifApi.deleteDestination(d.id); load() } catch (err) { toast.error(err instanceof Error ? err.message : String(err)) }
   }
 
   async function toggle(d: NotificationDestination) {
-    try { await notifApi.updateDestination(d.id, { enabled: !d.enabled }); load() } catch (err) { toast.error((err as Error).message) }
+    try { await notifApi.updateDestination(d.id, { enabled: !d.enabled }); load() } catch (err) { toast.error(err instanceof Error ? err.message : String(err)) }
   }
 
   async function test(d: NotificationDestination) {
     try { await notifApi.testDestination(d.id); toast.success(`Test sent to ${d.name}`) }
-    catch (err) { toast.error((err as Error).message) }
+    catch (err) { toast.error(err instanceof Error ? err.message : String(err)) }
   }
 
   return (
@@ -67,8 +67,8 @@ export default function NotificationDestinations() {
               <span className="badge bg-surface-2 text-text-muted border border-border">{d.type}</span>
               <span className="text-text-primary">{d.name}</span>
               <span className="text-text-muted truncate flex-1">{d.events || 'all events'}</span>
-              <button onClick={() => test(d)} className="btn-secondary text-xs py-0.5">Test</button>
-              <button onClick={() => remove(d)} className="text-text-muted hover:text-red">✕</button>
+              <button type="button" onClick={() => test(d)} className="btn-secondary text-xs py-0.5">Test</button>
+              <button type="button" onClick={() => remove(d)} aria-label={`Delete destination ${d.name}`} title="Delete" className="text-text-muted hover:text-red">✕</button>
             </div>
           ))}
         </div>

--- a/frontend/src/components/ToastHost.tsx
+++ b/frontend/src/components/ToastHost.tsx
@@ -15,11 +15,17 @@ export default function ToastHost() {
       {toasts.map(t => (
         <div
           key={t.id}
-          onClick={() => dismiss(t.id)}
-          className={`rounded border px-3 py-2 text-sm font-mono shadow-lg cursor-pointer ${styles[t.type] ?? styles.info}`}
+          className={`rounded border px-3 py-2 text-sm font-mono shadow-lg flex items-start gap-2 ${styles[t.type] ?? styles.info}`}
           role="status"
         >
-          {t.message}
+          <span className="flex-1">{t.message}</span>
+          <button
+            onClick={() => dismiss(t.id)}
+            aria-label="Dismiss notification"
+            className="shrink-0 opacity-70 hover:opacity-100"
+          >
+            ✕
+          </button>
         </div>
       ))}
     </div>,

--- a/frontend/src/components/UpgradeAllModal.tsx
+++ b/frontend/src/components/UpgradeAllModal.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 interface ServerProgress {
-  status: 'pending' | 'running' | 'done' | 'error'
+  status: 'pending' | 'running' | 'done' | 'error' | 'skipped'
   lines: string[]
   packagesUpgraded?: number
 }
@@ -96,6 +96,16 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
         if (pendingRef.current <= 0) {
           updateJob('upgrade-all', { status: 'complete', completedAt: Date.now(), action: undefined })
         }
+      } else if (msg.type === 'skipped') {
+        // Maintenance-window skip — terminal, but NOT a failure.
+        setProgress(p => ({
+          ...p,
+          [sid]: { ...p[sid], status: 'skipped', lines: [...(p[sid]?.lines || []), msg.data as string] },
+        }))
+        pendingRef.current -= 1
+        if (pendingRef.current <= 0) {
+          updateJob('upgrade-all', { status: 'complete', completedAt: Date.now(), action: undefined })
+        }
       } else if (msg.type === 'error') {
         setProgress(p => ({
           ...p,
@@ -137,7 +147,7 @@ export default function UpgradeAllModal({ servers, onClose, onMinimize }: Props)
   }
 
   const statusIcon = (s: ServerProgress['status']) =>
-    ({ pending: '⏳', running: '⚙️', done: '✓', error: '✗' }[s])
+    ({ pending: '⏳', running: '⚙️', done: '✓', error: '✗', skipped: '⏭️' }[s])
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">

--- a/frontend/src/hooks/useConfirm.ts
+++ b/frontend/src/hooks/useConfirm.ts
@@ -16,7 +16,13 @@ interface ConfirmState {
 
 export const useConfirmStore = create<ConfirmState>((set, get) => ({
   pending: null,
-  request: (opts) => new Promise<boolean>(resolve => set({ pending: { ...opts, resolve } })),
+  request: (opts) => new Promise<boolean>(resolve => {
+    // If a confirm is already open (double-click, overlapping actions), resolve the
+    // previous one as cancelled so its caller doesn't hang.
+    const prev = get().pending
+    if (prev) prev.resolve(false)
+    set({ pending: { ...opts, resolve } })
+  }),
   resolve: (v) => {
     const p = get().pending
     if (p) p.resolve(v)

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -283,12 +283,14 @@ export default function Dashboard() {
     if (!ids.length) return
     toast.info(`Checking ${ids.length} server${ids.length === 1 ? '' : 's'}…`)
     setChecking(c => { const n = new Set(c); ids.forEach(id => n.add(id)); return n })
+    let failures = 0
     await _runCapped(ids, 4, async (id) => {
-      try { await serversApi.check(id) } catch {}
+      try { await serversApi.check(id) } catch { failures++ }
       setChecking(c => { const n = new Set(c); n.delete(id); return n })
     })
     await load()
-    toast.success(`Checked ${ids.length} server${ids.length === 1 ? '' : 's'}`)
+    if (failures) toast.error(`Checked ${ids.length - failures}/${ids.length} — ${failures} failed`)
+    else toast.success(`Checked ${ids.length} server${ids.length === 1 ? '' : 's'}`)
   }
 
   function bulkUpgrade() {
@@ -308,9 +310,12 @@ export default function Dashboard() {
     const ids = [...selectedIds]
     if (!ids.length) return
     if (!enable && !await confirmDialog({ message: `Disable ${ids.length} server${ids.length === 1 ? '' : 's'}? They'll be skipped by checks and upgrades.`, confirmLabel: 'Disable', danger: true })) return
-    await _runCapped(ids, 4, async (id) => { try { await serversApi.update(id, { is_enabled: enable }) } catch {} })
+    let failures = 0
+    await _runCapped(ids, 4, async (id) => { try { await serversApi.update(id, { is_enabled: enable }) } catch { failures++ } })
     await load()
-    toast.success(`${enable ? 'Enabled' : 'Disabled'} ${ids.length} server${ids.length === 1 ? '' : 's'}`)
+    const verb = enable ? 'Enabled' : 'Disabled'
+    if (failures) toast.error(`${verb} ${ids.length - failures}/${ids.length} — ${failures} failed`)
+    else toast.success(`${verb} ${ids.length} server${ids.length === 1 ? '' : 's'}`)
   }
 
   async function confirmDoDisable() {
@@ -1062,7 +1067,7 @@ function RebootButton({ serverId, serverName, className = '' }: {
 // Server card
 // ---------------------------------------------------------------------------
 // Compact single-row representation used by the dashboard "List" density mode.
-function ServerRow({ server: s, checking, onCheck, reachable, selected, onToggleSelect }: {
+function ServerRow({ server: s, checking, onCheck, onToggleEnabled, reachable, selected, onToggleSelect }: {
   server: Server
   checking: boolean
   onCheck: () => void
@@ -1083,7 +1088,7 @@ function ServerRow({ server: s, checking, onCheck, reachable, selected, onToggle
     >
       {onToggleSelect && (
         <input type="checkbox" checked={!!selected} onClick={e => e.stopPropagation()} onChange={onToggleSelect}
-          className="w-3.5 h-3.5 accent-green shrink-0" title="Select" />
+          aria-label={`Select ${s.name}`} className="w-3.5 h-3.5 accent-green shrink-0" title="Select" />
       )}
       <StatusDot status={status} />
       {reachable === false && <span title="SSH unreachable" className="w-1.5 h-1.5 rounded-full bg-red inline-block shrink-0 -ml-1.5" />}
@@ -1102,6 +1107,7 @@ function ServerRow({ server: s, checking, onCheck, reachable, selected, onToggle
       </div>
       <div className="flex items-center gap-1 shrink-0" onClick={e => e.stopPropagation()}>
         <button onClick={onCheck} disabled={checking} className="btn-secondary text-xs py-0.5 px-2 disabled:opacity-50">{checking ? '…' : 'Check'}</button>
+        <button onClick={onToggleEnabled} className="btn-secondary text-xs py-0.5 px-2" title={s.is_enabled ? 'Disable server' : 'Enable server'}>{s.is_enabled ? 'Disable' : 'Enable'}</button>
       </div>
     </div>
   )
@@ -1134,7 +1140,7 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
     >
       {onToggleSelect && (
         <input type="checkbox" checked={!!selected} onClick={e => e.stopPropagation()} onChange={onToggleSelect}
-          className="absolute top-2 right-2 w-3.5 h-3.5 accent-green z-10" title="Select" />
+          aria-label={`Select ${s.name}`} className="absolute top-2 right-2 w-3.5 h-3.5 accent-green z-10" title="Select" />
       )}
       {s.is_enabled && s.is_reachable === false && (
         <div className="flex items-center gap-1.5 text-red text-[10px] font-mono bg-red/10 border border-red/20 rounded px-2 py-0.5 -mx-1 -mt-1">
@@ -1282,7 +1288,7 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
           (() => {
             // Config drift badge (issue #62): unmerged conffiles left by upgrades
             if (!s.drift_count || s.drift_count <= 0) return null
-            return <span key="drift" className="text-amber" title={`${s.drift_count} unmerged conffile(s) (.dpkg-dist/.ucf-dist) — review with dpkg-conf`}>⚠ drift {s.drift_count}</span>
+            return <span key="drift" className="text-amber" title={`${s.drift_count} unmerged conffile(s) (.dpkg-dist/.ucf-dist/.dpkg-new) — review and reconcile`}>⚠ drift {s.drift_count}</span>
           })(),
         ].filter(Boolean)
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1279,6 +1279,11 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
             if (s.boot_free_mb >= 100 && pct >= 10) return null
             return <span key="boot-low" className="text-red" title={`/boot has only ${s.boot_free_mb} MB free (${pct.toFixed(0)}% of ${s.boot_total_mb} MB) — run autoremove to clear old kernels`}>💾 /boot {s.boot_free_mb}M</span>
           })(),
+          (() => {
+            // Config drift badge (issue #62): unmerged conffiles left by upgrades
+            if (!s.drift_count || s.drift_count <= 0) return null
+            return <span key="drift" className="text-amber" title={`${s.drift_count} unmerged conffile(s) (.dpkg-dist/.ucf-dist) — review with dpkg-conf`}>⚠ drift {s.drift_count}</span>
+          })(),
         ].filter(Boolean)
 
         if (!shownLabels.length && !overflow && !statusItems.length) return null

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -29,6 +29,18 @@ export default function Reports() {
         <p className="text-sm text-text-muted">Compliance and SLA reports for audit / regulatory needs.</p>
       </div>
 
+      {/* Change record export (issue #62) */}
+      <div className="card p-3 flex flex-wrap items-center gap-2">
+        <span className="text-sm text-text-primary">Change record (upgrade activity)</span>
+        <span className="text-xs text-text-muted">last</span>
+        {[7, 30, 90].map(d => (
+          <span key={d} className="flex items-center gap-1">
+            <a className="btn-secondary text-xs py-0.5" href={`/api/reports/change-record?days=${d}&fmt=md`}>{d}d .md</a>
+            <a className="btn-secondary text-xs py-0.5" href={`/api/reports/change-record?days=${d}&fmt=csv`}>.csv</a>
+          </span>
+        ))}
+      </div>
+
       <div className="flex gap-1 border-b border-border">
         {(
           [

--- a/frontend/src/pages/Run.tsx
+++ b/frontend/src/pages/Run.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { servers as serversApi } from '@/api/client'
 import type { Server } from '@/types'
 import { toast } from '@/hooks/useToast'
+import { useAuthStore } from '@/hooks/useAuth'
 
 // Safe fleet command runner (issue #62): run an allowlisted command across selected
 // servers and group identical outputs ("47 said X, 3 said Y").
@@ -12,13 +13,27 @@ const ALLOWLISTED = [
 ]
 
 export default function Run() {
+  const { user } = useAuthStore()
+  const isAdmin = !!user?.is_admin
   const [serverList, setServerList] = useState<Server[]>([])
   const [selected, setSelected] = useState<Set<number>>(new Set())
   const [command, setCommand] = useState('uptime')
   const [running, setRunning] = useState(false)
   const [grouped, setGrouped] = useState<{ output: string; servers: string[]; count: number }[] | null>(null)
 
-  useEffect(() => { serversApi.list().then(s => setServerList(s.filter(x => x.is_enabled))).catch(() => {}) }, [])
+  useEffect(() => {
+    if (!isAdmin) return  // endpoint is admin-only; don't fetch for read-only users
+    serversApi.list().then(s => setServerList(s.filter(x => x.is_enabled))).catch(() => {})
+  }, [isAdmin])
+
+  if (!isAdmin) {
+    return (
+      <div className="max-w-5xl mx-auto">
+        <h1 className="text-lg font-mono text-text-primary mb-1">Fleet Command Runner</h1>
+        <p className="text-sm text-text-muted">This page is available to administrators only.</p>
+      </div>
+    )
+  }
 
   function toggle(id: number) {
     setSelected(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n })
@@ -31,7 +46,7 @@ export default function Run() {
     try {
       const r = await serversApi.runCommand([...selected], command.trim())
       setGrouped(r.grouped)
-    } catch (e) { toast.error((e as Error).message) }
+    } catch (e) { toast.error(e instanceof Error ? e.message : String(e)) }
     finally { setRunning(false) }
   }
 

--- a/frontend/src/pages/Run.tsx
+++ b/frontend/src/pages/Run.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react'
+import { servers as serversApi } from '@/api/client'
+import type { Server } from '@/types'
+import { toast } from '@/hooks/useToast'
+
+// Safe fleet command runner (issue #62): run an allowlisted command across selected
+// servers and group identical outputs ("47 said X, 3 said Y").
+const ALLOWLISTED = [
+  'uptime', 'uname -a', 'hostnamectl', 'df -h', 'free -h', 'who', 'last -n 5',
+  'cat /etc/os-release', 'systemctl --failed', 'dpkg --audit',
+  'ls -1 /var/run/reboot-required.pkgs', 'lsb_release -a',
+]
+
+export default function Run() {
+  const [serverList, setServerList] = useState<Server[]>([])
+  const [selected, setSelected] = useState<Set<number>>(new Set())
+  const [command, setCommand] = useState('uptime')
+  const [running, setRunning] = useState(false)
+  const [grouped, setGrouped] = useState<{ output: string; servers: string[]; count: number }[] | null>(null)
+
+  useEffect(() => { serversApi.list().then(s => setServerList(s.filter(x => x.is_enabled))).catch(() => {}) }, [])
+
+  function toggle(id: number) {
+    setSelected(prev => { const n = new Set(prev); n.has(id) ? n.delete(id) : n.add(id); return n })
+  }
+  const allSelected = serverList.length > 0 && selected.size === serverList.length
+
+  async function run() {
+    if (selected.size === 0 || !command.trim()) return
+    setRunning(true); setGrouped(null)
+    try {
+      const r = await serversApi.runCommand([...selected], command.trim())
+      setGrouped(r.grouped)
+    } catch (e) { toast.error((e as Error).message) }
+    finally { setRunning(false) }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-4">
+      <div>
+        <h1 className="text-lg font-mono text-text-primary mb-1">Fleet Command Runner</h1>
+        <p className="text-sm text-text-muted">
+          Run an allowlisted read-only command across selected servers and group identical outputs.
+          Raw commands require <span className="font-mono">ENABLE_TERMINAL=true</span>. Every run is audited.
+        </p>
+      </div>
+
+      <div className="card p-4 space-y-3">
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex-1 min-w-64">
+            <label className="label">Command</label>
+            <input list="cmd-allow" className="input text-sm font-mono w-full" value={command} onChange={e => setCommand(e.target.value)} />
+            <datalist id="cmd-allow">{ALLOWLISTED.map(c => <option key={c} value={c} />)}</datalist>
+          </div>
+          <button onClick={run} disabled={running || selected.size === 0} className="btn-primary text-sm">
+            {running ? 'Running…' : `Run on ${selected.size}`}
+          </button>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-text-muted uppercase tracking-wide">Servers</span>
+            <button onClick={() => setSelected(allSelected ? new Set() : new Set(serverList.map(s => s.id)))} className="text-xs text-cyan hover:underline">
+              {allSelected ? 'Clear' : 'Select all'}
+            </button>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-1">
+            {serverList.map(s => (
+              <label key={s.id} className="flex items-center gap-2 text-xs px-2 py-1 rounded border border-border/50 cursor-pointer hover:border-text-muted">
+                <input type="checkbox" checked={selected.has(s.id)} onChange={() => toggle(s.id)} className="w-3.5 h-3.5 accent-green" />
+                <span className="font-mono truncate">{s.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {grouped && (
+        <div className="space-y-2">
+          {grouped.length === 0 && <p className="text-text-muted text-sm">No output.</p>}
+          {grouped.map((g, i) => (
+            <div key={i} className="card overflow-hidden">
+              <div className="px-3 py-1.5 border-b border-border bg-surface-2 text-xs font-mono flex items-center gap-2">
+                <span className="text-text-primary">{g.count} server{g.count === 1 ? '' : 's'}</span>
+                <span className="text-text-muted truncate">{g.servers.join(', ')}</span>
+              </div>
+              <pre className="px-3 py-2 font-mono text-xs text-text-primary whitespace-pre-wrap overflow-x-auto max-h-64 overflow-y-auto">{g.output || '(no output)'}</pre>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -241,7 +241,7 @@ function BulkHoldButtons({
         toast.success(`${verb} succeeded on all ${serverIds.length} server(s).`)
       }
     } catch (e: unknown) {
-      toast.error((e as Error).message)
+      toast.error(e instanceof Error ? e.message : String(e))
     } finally {
       setBusy(null)
     }

--- a/frontend/src/pages/ServerDetail.tsx
+++ b/frontend/src/pages/ServerDetail.tsx
@@ -6,6 +6,7 @@ import type { Server, PackageInfo, UpdateHistory, ServerGroup, Tag } from '@/typ
 import { useJobStore } from '@/hooks/useJobStore'
 import { confirmDialog } from '@/hooks/useConfirm'
 import { toast } from '@/hooks/useToast'
+import { useAuthStore } from '@/hooks/useAuth'
 import { createUpgradeWebSocket, createSelectiveUpgradeWebSocket, createAutoremoveWebSocket, createAptUpdateWebSocket, createAutoSecurityUpdatesWebSocket, createAptProxyWebSocket, createEepromUpdateWebSocket, createDryRunWebSocket, createAptReposTestWebSocket, createPveUpgradeWebSocket } from '@/api/client'
 import DebInstallModal from '@/components/DebInstallModal'
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
@@ -971,7 +972,7 @@ function PackagesTab({ serverId, server, onRefresh }: { serverId: number; server
                                         onRefresh()
                                         loadPackages()
                                       } catch (err: unknown) {
-                                        toast.error((err as Error).message)
+                                        toast.error(err instanceof Error ? err.message : String(err))
                                       }
                                     }}
                                     className="text-blue/80 hover:text-blue text-[11px] font-mono"
@@ -1056,7 +1057,7 @@ function PackagesTab({ serverId, server, onRefresh }: { serverId: number; server
                       onRefresh()
                       loadPackages()
                     } catch (e: unknown) {
-                      toast.error((e as Error).message)
+                      toast.error(e instanceof Error ? e.message : String(e))
                     }
                   }}
                   className="hover:text-red text-blue/70"
@@ -1612,7 +1613,7 @@ function UpgradePanel({ serverId, server, onRefresh }: { serverId: number; serve
               onClick={async () => {
                 setImpactLoading(true)
                 try { setImpact(await serversApi.impact(serverId)) }
-                catch (e) { toast.error((e as Error).message) }
+                catch (e) { toast.error(e instanceof Error ? e.message : String(e)) }
                 finally { setImpactLoading(false) }
               }}
               disabled={impactLoading}
@@ -1837,6 +1838,7 @@ function SshShellPanel({ serverId }: { serverId: number }) {
 // History tab
 // ---------------------------------------------------------------------------
 function HistoryTab({ serverId }: { serverId: number }) {
+  const { user } = useAuthStore()
   const [items, setItems] = useState<UpdateHistory[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
@@ -1857,7 +1859,7 @@ function HistoryTab({ serverId }: { serverId: number }) {
     try {
       const r = await serversApi.rollback(serverId, snapshot)
       r.success ? toast.success('Rollback initiated — the server may reboot.') : toast.error(r.detail || 'Rollback failed')
-    } catch (e) { toast.error((e as Error).message) }
+    } catch (e) { toast.error(e instanceof Error ? e.message : String(e)) }
   }
 
   if (items.length === 0) return <p className="text-text-muted text-sm py-8 text-center">No upgrade history.</p>
@@ -1891,7 +1893,9 @@ function HistoryTab({ serverId }: { serverId: number }) {
                 <div className="flex items-center gap-2 text-xs font-mono">
                   <span className="text-text-muted">pre-upgrade snapshot:</span>
                   <span className="text-cyan">{h.snapshot_name}</span>
-                  <button onClick={() => rollback(h.snapshot_name!)} className="btn-danger text-xs py-0.5 ml-1">Roll back to this</button>
+                  {user?.is_admin && (
+                    <button onClick={() => rollback(h.snapshot_name!)} className="btn-danger text-xs py-0.5 ml-1">Roll back to this</button>
+                  )}
                 </div>
               )}
               {h.log_output && (
@@ -2488,7 +2492,7 @@ function HealthTab({ serverId }: { serverId: number }) {
       else toast.success(`Restarted ${unit}`)
       await load()
     } catch (e: unknown) {
-      toast.error((e as Error).message)
+      toast.error(e instanceof Error ? e.message : String(e))
     } finally {
       setRestarting(null)
     }

--- a/frontend/src/pages/ServerDetail.tsx
+++ b/frontend/src/pages/ServerDetail.tsx
@@ -1383,6 +1383,8 @@ function UpgradePanel({ serverId, server, onRefresh }: { serverId: number; serve
   const [dryRunLines, setDryRunLines] = useState<string[]>([])
   const [dryRunning, setDryRunning] = useState(false)
   const [showDryRun, setShowDryRun] = useState(false)
+  const [impact, setImpact] = useState<Awaited<ReturnType<typeof serversApi.impact>> | null>(null)
+  const [impactLoading, setImpactLoading] = useState(false)
   const [runtimePkgs, setRuntimePkgs] = useState<string[]>([])
   const [pveUpgrading, setPveUpgrading] = useState(false)
   const dryWsRef = useRef<WebSocket | null>(null)
@@ -1607,6 +1609,19 @@ function UpgradePanel({ serverId, server, onRefresh }: { serverId: number; serve
               {dryRunning ? 'Previewing…' : 'Preview'}
             </button>
             <button
+              onClick={async () => {
+                setImpactLoading(true)
+                try { setImpact(await serversApi.impact(serverId)) }
+                catch (e) { toast.error((e as Error).message) }
+                finally { setImpactLoading(false) }
+              }}
+              disabled={impactLoading}
+              className="btn-secondary"
+              title="Which services restart, and whether a reboot is truly required (needrestart)"
+            >
+              {impactLoading ? 'Checking…' : 'Impact'}
+            </button>
+            <button
               onClick={startUpgrade}
               disabled={!hasUpdates || (server.is_docker_host && runtimePkgs.length > 0)}
               className="btn-amber"
@@ -1615,6 +1630,36 @@ function UpgradePanel({ serverId, server, onRefresh }: { serverId: number; serve
               Run Upgrade
             </button>
           </div>
+        </div>
+      )}
+
+      {/* Impact preview (needrestart) */}
+      {impact && (
+        <div className="card p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-text-muted uppercase tracking-wide">Impact preview</span>
+            <button onClick={() => setImpact(null)} className="text-text-muted hover:text-text-primary text-xs">✕ close</button>
+          </div>
+          {!impact.available ? (
+            <p className="text-xs text-text-muted">{impact.detail || 'needrestart not available'}</p>
+          ) : (
+            <div className="space-y-1 text-xs font-mono">
+              <p className={impact.reboot_required ? 'text-red' : 'text-green'}>
+                {impact.reboot_required ? '↻ Reboot required (kernel)' : '✓ No reboot required'}
+                {impact.kernel_current && impact.kernel_expected && impact.kernel_current !== impact.kernel_expected && (
+                  <span className="text-text-muted"> — running {impact.kernel_current}, expected {impact.kernel_expected}</span>
+                )}
+              </p>
+              {impact.services && impact.services.length > 0 ? (
+                <div>
+                  <span className="text-text-muted">{impact.services.length} service(s) would restart:</span>
+                  <div className="text-text-primary mt-0.5">{impact.services.join(', ')}</div>
+                </div>
+              ) : (
+                <p className="text-text-muted">No services flagged for restart.</p>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1830,7 +1830,11 @@ function UpgradeHooksSection() {
                 rows={3}
                 placeholder={editing.hook_type === 'http' ? 'https://haproxy.lan/drain?node=web1' : 'systemctl stop nginx'}
               />
-              <p className="text-[10px] text-text-muted mt-1">Runs as the SSH user on the managed server. Use sudo if needed.</p>
+              <p className="text-[10px] text-text-muted mt-1">
+                {editing.hook_type === 'http'
+                  ? 'apt-ui POSTs a small JSON payload to this URL (sent from apt-ui, not the managed server).'
+                  : 'Runs as the SSH user on the managed server. Use sudo if needed.'}
+              </p>
             </div>
 
             <div>
@@ -2680,7 +2684,7 @@ function UsersTab() {
       await auth.updateUser(u.id, { is_admin: !u.is_admin })
       await reload()
     } catch (e: unknown) {
-      toast.error((e as Error).message)
+      toast.error(e instanceof Error ? e.message : String(e))
     }
   }
 
@@ -2690,7 +2694,7 @@ function UsersTab() {
       await auth.deleteUser(u.id)
       await reload()
     } catch (e: unknown) {
-      toast.error((e as Error).message)
+      toast.error(e instanceof Error ? e.message : String(e))
     }
   }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1680,6 +1680,7 @@ function UpgradeHooksSection() {
       name: '',
       phase,
       command: '',
+      hook_type: 'shell',
       sort_order: 0,
       enabled: true,
     })
@@ -1797,6 +1798,18 @@ function UpgradeHooksSection() {
             </div>
 
             <div>
+              <label className="label">Type</label>
+              <select
+                value={editing.hook_type ?? 'shell'}
+                onChange={e => setEditing({ ...editing, hook_type: e.target.value as 'shell' | 'http' })}
+                className="input text-sm"
+              >
+                <option value="shell">Shell command (over SSH)</option>
+                <option value="http">HTTP POST (call out from apt-ui)</option>
+              </select>
+            </div>
+
+            <div>
               <label className="label">Applies to</label>
               <select
                 value={editing.server_id ?? ''}
@@ -1809,13 +1822,13 @@ function UpgradeHooksSection() {
             </div>
 
             <div>
-              <label className="label">Command</label>
+              <label className="label">{editing.hook_type === 'http' ? 'URL' : 'Command'}</label>
               <textarea
                 value={editing.command ?? ''}
                 onChange={e => setEditing({ ...editing, command: e.target.value })}
                 className="input text-sm font-mono"
                 rows={3}
-                placeholder="systemctl stop nginx"
+                placeholder={editing.hook_type === 'http' ? 'https://haproxy.lan/drain?node=web1' : 'systemctl stop nginx'}
               />
               <p className="text-[10px] text-text-muted mt-1">Runs as the SSH user on the managed server. Use sudo if needed.</p>
             </div>

--- a/frontend/src/pages/Templates.tsx
+++ b/frontend/src/pages/Templates.tsx
@@ -8,7 +8,7 @@ import Convert from 'ansi-to-html'
 const ansiConvert = new Convert({ escapeXML: true })
 
 interface ServerProgress {
-  status: 'pending' | 'running' | 'done' | 'error'
+  status: 'pending' | 'running' | 'done' | 'error' | 'skipped'
   lines: string[]
 }
 
@@ -41,7 +41,7 @@ export default function Templates() {
       await templatesApi.remove(id)
       if (selected?.id === id) setSelected(null)
       load()
-    } catch (e) { toast.error((e as Error).message) }
+    } catch (e) { toast.error(e instanceof Error ? e.message : String(e)) }
   }
 
   return (
@@ -344,6 +344,8 @@ function ApplyTemplateModal({ template, onClose }: { template: Template; onClose
       } else if (msg.type === 'complete') {
         const d = msg.data as { success: boolean }
         setProgress(p => ({ ...p, [sid]: { ...p[sid], status: d.success ? 'done' : 'error' } }))
+      } else if (msg.type === 'skipped') {
+        setProgress(p => ({ ...p, [sid]: { ...p[sid], status: 'skipped', lines: [...(p[sid]?.lines || []), msg.data as string] } }))
       } else if (msg.type === 'error') {
         setProgress(p => ({ ...p, [sid]: { ...p[sid], status: 'error', lines: [...(p[sid]?.lines || []), msg.data as string] } }))
       }
@@ -351,7 +353,7 @@ function ApplyTemplateModal({ template, onClose }: { template: Template; onClose
   }
 
   const selectedServerObjs = serverList.filter(s => selectedServers.has(s.id))
-  const statusIcon = (s: ServerProgress['status']) => ({ pending: '⏳', running: '⚙️', done: '✓', error: '✗' }[s])
+  const statusIcon = (s: ServerProgress['status']) => ({ pending: '⏳', running: '⚙️', done: '✓', error: '✗', skipped: '⏭️' }[s])
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -81,6 +81,7 @@ export interface Server {
   boot_free_mb: number | null            // free MB on /boot (issue #43)
   boot_total_mb: number | null           // total MB on /boot
   snapshot_capability: 'btrfs' | 'zfs' | 'container' | 'none' | null  // (issue #35)
+  drift_count: number | null              // unmerged conffiles (issue #62)
   os_eol_date: string | null              // ISO date when OS reaches EOL (issue #57)
   os_eol_days_remaining: number | null    // negative when past EOL; null when unknown
   os_eol_severity: 'ok' | 'warning' | 'alert' | 'expired' | 'unknown' | null


### PR DESCRIPTION
Roadmap — **novel ideas (5/5) + two ambitious items**. Stacked on #69 → … → #64.

Part of #62.

## Novel ideas (all 5)
- **Upgrade impact preview** (`00066b7`) — `GET /api/servers/{id}/impact` via needrestart: which services restart + whether a reboot is truly required; shown in the Upgrade tab.
- **Safe fleet command runner** (`d2573d6`) — allowlisted, audited, concurrency-capped command across selected servers with **grouped identical outputs**; new **Run** page + nav.
- **Configuration drift detection** (`8d30ef4`) — counts unmerged conffiles (`.dpkg-dist`/`.ucf-dist`) per check → `drift_count` + a dashboard badge.
- **HTTP/webhook hook type** (`1a9de20`) — pre/post hooks can POST out (drain LB, silence alerts) as the box reboots; metadata endpoints blocked.
- **Maintenance change-record / patch report** (`36bfe54`) — `GET /api/reports/change-record?fmt=md|csv` exportable change ticket; download links on Reports.

## Ambitious (the tractable two)
- **Self-updating EOL data** (`7d61767`) — daily endoflife.date sync (ubuntu/debian/proxmox-ve) cached to disk, bundled table as fallback.
- **Dependency/anti-affinity ordering** (`e29fd5c`) — staged rollout sorts each ring by an `order:N` tag so HA pairs / DB primary-replica patch in a safe sequence.

## DB
- New table `notification_destinations` (in #68); new columns `update_history.snapshot_name`, `schedule_config.{snapshot_before_upgrade,canary_health_check}`, `upgrade_hooks.hook_type`, `server_stats.drift_count`, `api_tokens.scopes`, `users.totp_last_counter` — all with migrations.

## Deferred (need dedicated PRs — see issue comment)
Durable-rollout state machine, persistent job-queue control plane, CVE remediation planner (blocked on the empty CVE pipeline, a bugs-issue defect), and OIDC/SSO are each large/architectural or externally-dependent and are intentionally **not** crammed in here.

## Testing
- ✅ `make ci` green across the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
