### PR TITLE
feat: actionable config-drift drill-down + themed bulk-select checkbox

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -227,6 +227,8 @@ async def init_db():
             "ALTER TABLE upgrade_hooks ADD COLUMN hook_type TEXT DEFAULT 'shell'",
             # Config drift detection (issue #62)
             "ALTER TABLE server_stats ADD COLUMN drift_count INTEGER",
+            # Config drift — the actual drifted conffile paths (JSON list, capped) (issue #62)
+            "ALTER TABLE server_stats ADD COLUMN drift_files TEXT",
             # api_tokens table is created by Base.metadata.create_all (new table — no migration needed)
             # auth_event_log + fleet_snapshots are new tables — created by create_all, no migration needed
         ]

--- a/backend/models.py
+++ b/backend/models.py
@@ -260,6 +260,7 @@ class ServerStats(Base):
     boot_total_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)       # total MB on /boot
     snapshot_capability: Mapped[str | None] = mapped_column(Text, nullable=True)    # 'btrfs' | 'zfs' | 'container' | 'none' (issue #35)
     drift_count: Mapped[int | None] = mapped_column(Integer, nullable=True)         # unmerged conffiles (.dpkg-dist/.ucf-dist) (issue #62)
+    drift_files: Mapped[str | None] = mapped_column(Text, nullable=True)            # JSON list of the actual drifted conffile paths (capped) (issue #62)
 
     server: Mapped["Server"] = relationship("Server", back_populates="server_stats")
 

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -276,6 +276,11 @@ async def _build_server_out(
         boot_total_mb=stats_row.boot_total_mb if stats_row else None,
         snapshot_capability=stats_row.snapshot_capability if stats_row else None,
         drift_count=stats_row.drift_count if stats_row else None,
+        drift_files=(
+            json.loads(stats_row.drift_files)
+            if stats_row and stats_row.drift_files
+            else None
+        ),
         os_eol_date=eol["date"],
         os_eol_days_remaining=eol["days_remaining"],
         os_eol_severity=eol["severity"],

--- a/backend/routers/servers.py
+++ b/backend/routers/servers.py
@@ -238,6 +238,17 @@ async def _build_server_out(
     # OS EOL status (issue #57) — derived from os_info string at serialize time
     eol = get_eol_status_from_os_info(server.os_info)
 
+    # Config drift file list — guard the JSON parse (issue #62): malformed data
+    # (corruption / manual edits / partial writes) must not 500 the whole endpoint.
+    drift_files = None
+    if stats_row and stats_row.drift_files:
+        try:
+            _parsed = json.loads(stats_row.drift_files)
+            if isinstance(_parsed, list):
+                drift_files = [str(p) for p in _parsed]
+        except (ValueError, TypeError):
+            drift_files = None
+
     return ServerOut(
         id=server.id,
         name=server.name,
@@ -276,11 +287,7 @@ async def _build_server_out(
         boot_total_mb=stats_row.boot_total_mb if stats_row else None,
         snapshot_capability=stats_row.snapshot_capability if stats_row else None,
         drift_count=stats_row.drift_count if stats_row else None,
-        drift_files=(
-            json.loads(stats_row.drift_files)
-            if stats_row and stats_row.drift_files
-            else None
-        ),
+        drift_files=drift_files,
         os_eol_date=eol["date"],
         os_eol_days_remaining=eol["days_remaining"],
         os_eol_severity=eol["severity"],

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -180,6 +180,7 @@ class ServerOut(BaseModel):
     boot_total_mb: Optional[int] = None             # total MB on /boot
     snapshot_capability: Optional[str] = None       # 'btrfs' | 'zfs' | 'container' | 'none' (issue #35)
     drift_count: Optional[int] = None                # unmerged conffiles (issue #62)
+    drift_files: Optional[list[str]] = None          # the actual drifted conffile paths (capped) (issue #62)
     os_eol_date: Optional[str] = None                # ISO date string of OS EOL (issue #57)
     os_eol_days_remaining: Optional[int] = None      # negative when past EOL
     os_eol_severity: Optional[str] = None            # 'ok' | 'warning' | 'alert' | 'expired' | 'unknown'

--- a/backend/update_checker.py
+++ b/backend/update_checker.py
@@ -183,7 +183,7 @@ async def _gather_stats(server: Server) -> dict:
         # post-patch breakage cause and are cheap to count.
         "drift": (
             "find /etc \\( -name '*.dpkg-dist' -o -name '*.ucf-dist' -o -name '*.dpkg-new' \\) "
-            "2>/dev/null | wc -l"
+            "2>/dev/null | sort | head -n 200"
         ),
         # /boot disk usage (separate partition on most distros — kernel buildup fills it)
         "boot_disk": "df -P -BM /boot 2>/dev/null | awk 'NR==2{gsub(\"M\",\"\",$2); gsub(\"M\",\"\",$4); print $2\" \"$4}' || echo ''",
@@ -360,9 +360,11 @@ async def _gather_stats(server: Server) -> dict:
         snapshot_capability = None
 
     drift_raw = results.get("drift")
+    drift_files: list[str] = []
     drift_count = None
-    if drift_raw and drift_raw.stdout.strip().isdigit():
-        drift_count = int(drift_raw.stdout.strip())
+    if drift_raw and drift_raw.stdout:
+        drift_files = [ln.strip() for ln in drift_raw.stdout.splitlines() if ln.strip()]
+        drift_count = len(drift_files)
 
     return {
         "uptime_seconds": uptime_seconds,
@@ -385,6 +387,7 @@ async def _gather_stats(server: Server) -> dict:
         "boot_free_mb": boot_free_mb,
         "snapshot_capability": snapshot_capability,
         "drift_count": drift_count,
+        "drift_files": json.dumps(drift_files) if drift_files else None,
     }
 
 
@@ -574,6 +577,7 @@ async def check_server(
         boot_free_mb=stats.get("boot_free_mb"),
         snapshot_capability=stats.get("snapshot_capability"),
         drift_count=stats.get("drift_count"),
+        drift_files=stats.get("drift_files"),
     )
     db.add(stat_row)
 

--- a/backend/update_checker.py
+++ b/backend/update_checker.py
@@ -178,12 +178,16 @@ async def _gather_stats(server: Server) -> dict:
             "elif [ -f /.dockerenv ] || systemd-detect-virt 2>/dev/null | grep -qE '^(lxc|docker)$'; then echo container; "
             "else echo none; fi"
         ),
-        # Config drift (issue #62) — count unmerged conffiles left by past upgrades.
+        # Config drift (issue #62) — unmerged conffiles left by past upgrades.
         # These (.dpkg-dist/.ucf-dist/.dpkg-new under /etc) are the most common
-        # post-patch breakage cause and are cheap to count.
+        # post-patch breakage cause and are cheap to find. Emit the TRUE (uncapped)
+        # count on line 1, then up to 200 sorted paths — so the count/badge stay
+        # accurate on hosts with >200 drifted files while the stored list is bounded.
         "drift": (
-            "find /etc \\( -name '*.dpkg-dist' -o -name '*.ucf-dist' -o -name '*.dpkg-new' \\) "
-            "2>/dev/null | sort | head -n 200"
+            "d=$(find /etc \\( -name '*.dpkg-dist' -o -name '*.ucf-dist' -o -name '*.dpkg-new' \\) "
+            "2>/dev/null | sort); "
+            "printf '%s\\n' \"$(printf '%s\\n' \"$d\" | grep -c .)\"; "
+            "printf '%s\\n' \"$d\" | head -n 200"
         ),
         # /boot disk usage (separate partition on most distros — kernel buildup fills it)
         "boot_disk": "df -P -BM /boot 2>/dev/null | awk 'NR==2{gsub(\"M\",\"\",$2); gsub(\"M\",\"\",$4); print $2\" \"$4}' || echo ''",
@@ -359,12 +363,18 @@ async def _gather_stats(server: Server) -> dict:
     if snapshot_capability not in ("btrfs", "zfs", "container", "none"):
         snapshot_capability = None
 
+    # Line 1 is the true (uncapped) count; remaining lines are up to 200 paths.
     drift_raw = results.get("drift")
     drift_files: list[str] = []
     drift_count = None
     if drift_raw and drift_raw.stdout:
-        drift_files = [ln.strip() for ln in drift_raw.stdout.splitlines() if ln.strip()]
-        drift_count = len(drift_files)
+        _lines = drift_raw.stdout.splitlines()
+        if _lines:
+            _first = _lines[0].strip()
+            drift_count = int(_first) if _first.isdigit() else None
+            drift_files = [ln.strip() for ln in _lines[1:] if ln.strip()]
+            if drift_count is None:  # unexpected output shape — fall back to list length
+                drift_count = len(drift_files)
 
     return {
         "uptime_seconds": uptime_seconds,

--- a/frontend/src/components/DriftModal.tsx
+++ b/frontend/src/components/DriftModal.tsx
@@ -1,0 +1,120 @@
+import { createPortal } from 'react-dom'
+import { useEscapeKey } from '@/hooks/useEscapeKey'
+import { toast } from '@/hooks/useToast'
+import type { Server } from '@/types'
+
+interface Props {
+  server: Server
+  onClose: () => void
+}
+
+// dpkg/ucf leave the maintainer's new config next to the live one with these suffixes.
+const SUFFIXES = ['.dpkg-dist', '.dpkg-new', '.ucf-dist', '.dpkg-old']
+
+/** The live config file that a leftover shadows (strip the suffix). */
+function livePath(leftover: string): string {
+  for (const s of SUFFIXES) {
+    if (leftover.endsWith(s)) return leftover.slice(0, -s.length)
+  }
+  return leftover
+}
+
+async function copy(text: string, label = 'Copied to clipboard') {
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success(label)
+  } catch (e) {
+    toast.error(`Copy failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+}
+
+export default function DriftModal({ server, onClose }: Props) {
+  useEscapeKey(onClose, true)
+
+  const files = server.drift_files ?? []
+  const count = server.drift_count ?? files.length
+  const diffCommands = files.map(f => `diff ${livePath(f)} ${f}`).join('\n')
+  const rmCommands = files.map(f => `rm ${f}`).join('\n')
+
+  const modal = (
+    <div
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4"
+      onClick={e => { if (e.target === e.currentTarget) { e.stopPropagation(); onClose() } }}
+    >
+      <div
+        className="bg-surface border border-border rounded-lg w-full max-w-2xl max-h-[90vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-4 border-b border-border flex items-center justify-between">
+          <h2 className="font-mono text-sm text-text-primary">
+            <span className="text-amber">⚠ Config drift</span> — {server.name}
+          </h2>
+          <button onClick={onClose} className="text-text-muted hover:text-red" aria-label="Close">✕</button>
+        </div>
+
+        {/* Body */}
+        <div className="p-4 overflow-y-auto flex flex-col gap-3 text-sm">
+          <p className="text-text-muted leading-relaxed">
+            <span className="text-text-primary font-mono">{count}</span> unmerged conffile{count === 1 ? '' : 's'} under{' '}
+            <code className="text-text-primary">/etc</code>, as of the last check. An upgrade shipped a new default
+            config, but your modified version was kept (the <code className="text-text-primary">confdef/confold</code>{' '}
+            policy) — so the maintainer's new version is sitting <em>unapplied</em> right next to your live file.
+            Usually harmless, but a missing new directive can bite on the next service restart.
+          </p>
+
+          {files.length > 0 ? (
+            <>
+              <div className="border border-border rounded divide-y divide-border/60">
+                {files.map(f => (
+                  <div key={f} className="flex items-center gap-2 px-2.5 py-1.5 font-mono text-xs">
+                    <span className="flex-1 min-w-0 break-all">
+                      <span className="text-amber">{f}</span>
+                      <span className="text-text-muted block">shadows {livePath(f)}</span>
+                    </span>
+                    <button
+                      onClick={() => copy(`diff ${livePath(f)} ${f}`, 'diff command copied')}
+                      className="btn-secondary text-[10px] py-0.5 shrink-0"
+                      title="Copy the diff command for this file"
+                    >
+                      Copy diff
+                    </button>
+                  </div>
+                ))}
+                {count > files.length && (
+                  <div className="px-2.5 py-1.5 text-[11px] text-text-muted font-mono">
+                    + {count - files.length} more (list capped at {files.length})
+                  </div>
+                )}
+              </div>
+
+              <div className="text-text-muted text-xs leading-relaxed">
+                To reconcile each: review the diff, merge anything you want into the live file, then delete the
+                leftover (<code className="text-text-primary">rm</code>). The leftover is the file with the suffix.
+              </div>
+
+              <div className="flex gap-2 flex-wrap">
+                <button onClick={() => copy(diffCommands, `${files.length} diff command(s) copied`)} className="btn-secondary text-xs">
+                  Copy all diff commands
+                </button>
+                <button onClick={() => copy(rmCommands, `${files.length} rm command(s) copied`)} className="btn-secondary text-xs">
+                  Copy all rm commands
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="text-text-muted text-xs leading-relaxed border border-border rounded p-3">
+              The specific file paths weren't captured in the last check (older data). Run <strong className="text-text-primary">Check</strong> on
+              this server to populate them, or list them over SSH:
+              <pre className="mt-2 bg-bg rounded p-2 overflow-x-auto text-text-primary">
+                find /etc \( -name '*.dpkg-dist' -o -name '*.ucf-dist' -o -name '*.dpkg-new' \)
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+
+  return createPortal(modal, document.body)
+}

--- a/frontend/src/components/SelectCheckbox.tsx
+++ b/frontend/src/components/SelectCheckbox.tsx
@@ -1,0 +1,44 @@
+/**
+ * Themed selection checkbox used for bulk server selection (Dashboard grid + list views).
+ * Native checkboxes render as a white box that clashes with the dark theme, so this uses
+ * `appearance-none` with theme tokens: dark `surface` fill + `border`, green when checked,
+ * with a crisp white SVG checkmark overlay. Works in both dark and light themes.
+ */
+export default function SelectCheckbox({
+  checked,
+  onChange,
+  label,
+  className = '',
+}: {
+  checked: boolean
+  onChange: () => void
+  label: string
+  className?: string
+}) {
+  return (
+    <span
+      className={`relative inline-flex w-3.5 h-3.5 shrink-0 ${className}`}
+      onClick={e => e.stopPropagation()}
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        aria-label={label}
+        title={label}
+        className="peer appearance-none w-3.5 h-3.5 rounded-[3px] border border-border bg-surface cursor-pointer transition-colors hover:border-green/70 checked:bg-green checked:border-green focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-green/60"
+      />
+      <svg
+        viewBox="0 0 12 12"
+        className="pointer-events-none absolute inset-0 m-auto h-3.5 w-3.5 p-[2px] text-white opacity-0 peer-checked:opacity-100"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M2.5 6.5 L5 9 L9.5 3.5" />
+      </svg>
+    </span>
+  )
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/hooks/useAuth'
 import { useJobStore } from '@/hooks/useJobStore'
 import { useServersStore } from '@/hooks/useServers'
 import StatusDot from '@/components/StatusDot'
+import SelectCheckbox from '@/components/SelectCheckbox'
 import FleetTrendCard from '@/components/FleetTrendCard'
 import { toast } from '@/hooks/useToast'
 import { confirmDialog } from '@/hooks/useConfirm'
@@ -15,6 +16,7 @@ import UpgradeAllModal from '@/components/UpgradeAllModal'
 import AutoremoveAllModal from '@/components/AutoremoveAllModal'
 import RollingRebootModal from '@/components/RollingRebootModal'
 import PackageInstallModal from '@/components/PackageInstallModal'
+import DriftModal from '@/components/DriftModal'
 import CopySshButton from '@/components/CopySshButton'
 import { PieChart, Pie, Cell, Tooltip as ReTooltip } from 'recharts'
 
@@ -1087,8 +1089,7 @@ function ServerRow({ server: s, checking, onCheck, onToggleEnabled, reachable, s
       onClick={() => navigate(`/servers/${s.id}`)}
     >
       {onToggleSelect && (
-        <input type="checkbox" checked={!!selected} onClick={e => e.stopPropagation()} onChange={onToggleSelect}
-          aria-label={`Select ${s.name}`} className="w-3.5 h-3.5 accent-green shrink-0" title="Select" />
+        <SelectCheckbox checked={!!selected} onChange={onToggleSelect} label={`Select ${s.name}`} />
       )}
       <StatusDot status={status} />
       {reachable === false && <span title="SSH unreachable" className="w-1.5 h-1.5 rounded-full bg-red inline-block shrink-0 -ml-1.5" />}
@@ -1126,6 +1127,7 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
   const status = checking ? 'checking' : serverStatus(s)
   const c = s.latest_check
   const [showInstall, setShowInstall] = useState(false)
+  const [showDrift, setShowDrift] = useState(false)
 
   // Use the first group color for left border accent
   const primaryGroupColor = (s.groups ?? [])[0]?.color || s.group_color || null
@@ -1134,14 +1136,10 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
 
   return (
     <div
-      className={`card relative p-3 flex flex-col gap-2 transition-colors cursor-pointer ${!s.is_enabled ? 'opacity-50' : s.is_reachable === false ? 'opacity-60' : ''} ${selected ? 'ring-1 ring-green/60' : ''}`}
+      className={`card group/card relative p-3 flex flex-col gap-2 transition-colors cursor-pointer ${!s.is_enabled ? 'opacity-50' : s.is_reachable === false ? 'opacity-60' : ''} ${selected ? 'ring-1 ring-green/60' : ''}`}
       style={primaryGroupColor ? { borderLeft: `3px solid ${s.is_reachable === false ? '#ef4444' : primaryGroupColor}66` } : (s.is_reachable === false ? { borderLeft: '3px solid #ef444466' } : undefined)}
       onClick={() => navigate(`/servers/${s.id}`)}
     >
-      {onToggleSelect && (
-        <input type="checkbox" checked={!!selected} onClick={e => e.stopPropagation()} onChange={onToggleSelect}
-          aria-label={`Select ${s.name}`} className="absolute top-2 right-2 w-3.5 h-3.5 accent-green z-10" title="Select" />
-      )}
       {s.is_enabled && s.is_reachable === false && (
         <div className="flex items-center gap-1.5 text-red text-[10px] font-mono bg-red/10 border border-red/20 rounded px-2 py-0.5 -mx-1 -mt-1">
           <span className="w-1.5 h-1.5 rounded-full bg-red inline-block shrink-0" />
@@ -1153,7 +1151,21 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
         {/* Left: name, hostname, OS */}
         <div className="flex-1 min-w-0 space-y-0.5">
           <div className="flex items-center gap-1.5">
-            <StatusDot status={status} />
+            {/* Status dot doubles as the bulk-select control: the checkbox replaces the
+                dot on hover or when the card is selected — no overlap with corner status. */}
+            <span className="relative inline-flex items-center justify-center w-3.5 h-3.5 shrink-0">
+              {onToggleSelect && (
+                <SelectCheckbox
+                  checked={!!selected}
+                  onChange={onToggleSelect}
+                  label={`Select ${s.name}`}
+                  className={selected ? '' : 'hidden group-hover/card:inline-flex'}
+                />
+              )}
+              <span className={selected ? 'hidden' : (onToggleSelect ? 'group-hover/card:hidden' : '')}>
+                <StatusDot status={status} />
+              </span>
+            </span>
             <span className="font-mono text-sm text-text-primary truncate">{s.name}</span>
           </div>
           <div className="flex items-center font-mono text-xs text-text-muted truncate group/host">
@@ -1286,9 +1298,20 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
             return <span key="boot-low" className="text-red" title={`/boot has only ${s.boot_free_mb} MB free (${pct.toFixed(0)}% of ${s.boot_total_mb} MB) — run autoremove to clear old kernels`}>💾 /boot {s.boot_free_mb}M</span>
           })(),
           (() => {
-            // Config drift badge (issue #62): unmerged conffiles left by upgrades
+            // Config drift badge (issue #62): unmerged conffiles left by upgrades.
+            // Clicking opens a detail modal (file list + how to reconcile) — stop the
+            // click from bubbling to the card's navigate-to-server handler.
             if (!s.drift_count || s.drift_count <= 0) return null
-            return <span key="drift" className="text-amber" title={`${s.drift_count} unmerged conffile(s) (.dpkg-dist/.ucf-dist/.dpkg-new) — review and reconcile`}>⚠ drift {s.drift_count}</span>
+            return (
+              <button
+                key="drift"
+                onClick={e => { e.stopPropagation(); setShowDrift(true) }}
+                className="text-amber hover:text-amber/80 hover:underline cursor-pointer"
+                title={`${s.drift_count} unmerged conffile(s) (.dpkg-dist/.ucf-dist/.dpkg-new) — click to review and reconcile`}
+              >
+                ⚠ drift {s.drift_count}
+              </button>
+            )
           })(),
         ].filter(Boolean)
 
@@ -1372,6 +1395,9 @@ function ServerCard({ server: s, checking, onCheck, onToggleEnabled, reachable, 
           serverName={s.name}
           onClose={() => setShowInstall(false)}
         />
+      )}
+      {showDrift && (
+        <DriftModal server={s} onClose={() => setShowDrift(false)} />
       )}
     </div>
   )

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -82,6 +82,7 @@ export interface Server {
   boot_total_mb: number | null           // total MB on /boot
   snapshot_capability: 'btrfs' | 'zfs' | 'container' | 'none' | null  // (issue #35)
   drift_count: number | null              // unmerged conffiles (issue #62)
+  drift_files: string[] | null            // the actual drifted conffile paths, capped (issue #62)
   os_eol_date: string | null              // ISO date when OS reaches EOL (issue #57)
   os_eol_days_remaining: number | null    // negative when past EOL; null when unknown
   os_eol_severity: 'ok' | 'warning' | 'alert' | 'expired' | 'unknown' | null


### PR DESCRIPTION
## Summary

Two server-card fixes on the Dashboard, found during manual testing of the freshly-merged roadmap work.

### 1. Bulk-select checkbox restyle (the white box in the corner)
The bulk-selection checkbox was a raw native `<input type="checkbox">` pinned `absolute top-2 right-2` — so it **sat on top of the `✓ OK` status badge** and rendered as a **white box that clashed with the dark theme**.

- New themed [`SelectCheckbox`](frontend/src/components/SelectCheckbox.tsx): `appearance-none` with theme tokens (`surface` fill + `border`, green when checked, crisp white SVG check). Works in dark **and** light themes.
- On the card, the **status dot now doubles as the select control** — the checkbox swaps in for the dot on hover or when the card is selected. No overlap, no idle clutter, no layout shift.
- Same themed checkbox applied to the **list view** rows for consistency.

### 2. Config-drift drill-down (the "what do I do with this?" badge)
The `⚠ drift N` badge only showed a *count*, and clicking it just bubbled up to the card's navigate handler — landing you on Packages by accident, with no idea which files were affected.

- The badge is now a real `<button>` that `stopPropagation()`s and opens a new [`DriftModal`](frontend/src/components/DriftModal.tsx) (portal + Escape, matching the other modals).
- The modal **lists the actual drifted conffiles**, shows the live file each one shadows, and provides **per-file `Copy diff`** plus **Copy all diff / rm commands** to reconcile them — with a plain-English explanation of why drift happens (the `confdef/confold` upgrade policy) and how to fix it.
- Backend now **captures the file paths**, not just a count:
  - new `server_stats.drift_files` column ([models.py](backend/models.py)) + migration ([database.py](backend/database.py))
  - detection changed from `find … | wc -l` to a capped path list ([update_checker.py](backend/update_checker.py))
  - threaded through the schema ([schemas.py](backend/schemas.py)) and response builder ([servers.py](backend/routers/servers.py)) and the TS types.

**Note:** the file list populates on the **next Check** of a server. Existing rows (checked before this change) show a graceful fallback explaining how to list them, until re-checked.

## Testing
- `make ci` green (Python syntax + import check, frontend `tsc` + vite build — 715 modules).
- Migration verified to apply to an existing DB (`drift_files` column present); container builds healthy and serves the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
