### PR TITLE
fix: Upgrade All crash — 'cannot access local variable select' (regression in 2026.06.06-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to apt-ui are documented here.
 
 ---
 
+## [2026.06.06-02] — 2026-06-06
+
+### Fixed
+
+- **"Upgrade All" (and selective upgrade) failed on every server with `cannot access local variable 'select' where it is not associated with a value`.** `upgrade_server` and `upgrade_packages_selective` in `backend/upgrade_manager.py` each carried a redundant nested `from sqlalchemy import select`; per Python's static scoping rules that makes `select` a function-local name for the *entire* function, so the module-level `select` used earlier in `upgrade_server` (the pre-upgrade snapshot config lookup added in 2026.06.06-01) raised at runtime — even though the nested import line never executed during a batch upgrade (`skip_notify=True`). Removed the nested imports so the module-level `select` is used throughout. Regression introduced in 2026.06.06-01.
+
+---
+
 ## [2026.06.06-01] — 2026-06-06
 
 The largest release to date: the full enhancement roadmap ([#62](https://github.com/mzac/apt-ui/issues/62)) — 24 features across UX, security, automation, integrations, and observability — plus a frontend correctness sweep of 40 verified bugs ([#61](https://github.com/mzac/apt-ui/issues/61)). Both were produced by multi-agent reviews and landed across PRs [#63](https://github.com/mzac/apt-ui/pull/63)–[#71](https://github.com/mzac/apt-ui/pull/71).

--- a/backend/upgrade_manager.py
+++ b/backend/upgrade_manager.py
@@ -343,7 +343,6 @@ async def upgrade_server(
                     from backend.database import AsyncSessionLocal
                     from backend.models import NotificationConfig
                     from backend.notifier import notify_upgrade_complete
-                    from sqlalchemy import select
 
                     async with AsyncSessionLocal() as ndb:
                         cfg_res = await ndb.execute(select(NotificationConfig).where(NotificationConfig.id == 1))
@@ -478,7 +477,6 @@ async def upgrade_packages_selective(
                 from backend.database import AsyncSessionLocal
                 from backend.models import NotificationConfig
                 from backend.notifier import notify_upgrade_complete
-                from sqlalchemy import select
 
                 async with AsyncSessionLocal() as ndb:
                     cfg_res = await ndb.execute(select(NotificationConfig).where(NotificationConfig.id == 1))


### PR DESCRIPTION
## Summary

Hotfix for a **critical regression in `2026.06.06-01`**: **Upgrade All** (and selective upgrade) failed on every server with:

```
[host] cannot access local variable 'select' where it is not associated with a value
```

## Root cause

`upgrade_server` and `upgrade_packages_selective` in [backend/upgrade_manager.py](backend/upgrade_manager.py) each carried a redundant **nested** `from sqlalchemy import select`. Per Python's static scoping rules, assigning a name anywhere in a function makes it *function-local for the entire function* — so the module-level `select` used earlier in `upgrade_server` (the pre-upgrade snapshot config lookup, `select(ScheduleConfig)…`, added in `2026.06.06-01`) raised at runtime. The nested import never even runs during a batch upgrade (`skip_notify=True`), but the scoping rule is static, so the early call still failed → every server errored.

## Fix

Removed both nested imports; the module-level `select` (line 18) is used throughout. The other nested imports in the codebase already alias as `_sel` / `_select` to avoid exactly this shadow — these two were the unaliased outliers.

## Verification

- **Definitive runtime check** — `select` is no longer treated as a local:
  - before: `select` ∈ `upgrade_server.__code__.co_varnames` and `upgrade_packages_selective.__code__.co_varnames`
  - after: `select` ∉ either (resolves to the module global)
- `make ci` green (Python syntax + import check, frontend build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
