### PR TITLE
fix: persist the DB encryption key so per-server SSH keys survive restarts (#77)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,7 +33,7 @@ flowchart TB
 
         subgraph data_layer["💾 Data layer"]
             DB[("🗄 SQLite · /data/apt-ui.db<br/>20 tables · 50+ migrations<br/>servers · groups · tags · users<br/>update_checks · update_history<br/>server_stats · notification_config<br/>schedule_config · maintenance_windows<br/>upgrade_hooks · ssh_audit_log · api_tokens<br/>notification_log · templates · …")]
-            CRYPTO["🔐 Fernet Encryption<br/>AES-128-CBC + HMAC-SHA256<br/>Per-server SSH keys · TOTP secrets<br/>Key: SHA-256(ENCRYPTION_KEY)<br/>fallback → JWT_SECRET"]
+            CRYPTO["🔐 Fernet Encryption<br/>AES-128-CBC + HMAC-SHA256<br/>Per-server SSH keys · TOTP secrets<br/>Key: SHA-256(ENCRYPTION_KEY)<br/>fallback → JWT_SECRET → DB app_config"]
         end
 
         SSH_CLIENT["🔗 asyncssh client<br/>Fresh connection per command<br/>known_hosts=None (trusted LAN)<br/>Auth priority:<br/>1. Per-server encrypted key<br/>2. SSH agent socket<br/>3. Global SSH_PRIVATE_KEY"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to apt-ui are documented here.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Per-server SSH keys (and TOTP 2FA secrets) stopped working after every container restart** ([#77](https://github.com/mzac/apt-ui/issues/77)). When neither `ENCRYPTION_KEY` nor `JWT_SECRET` was set — the default for `docker-compose.yml`, where both are commented out — `backend/crypto.py` fell back to a **random Fernet key generated in memory at startup**. Keys were encrypted correctly, but the next restart derived a different key, so every stored blob became undecryptable and every server with a custom key silently fell back to the global `SSH_PRIVATE_KEY` / agent auth (or failed to connect at all). The encryption key is now resolved once at startup by `seed_defaults()` and persisted in the `app_config` table alongside the JWT secret, which lives on the mounted data volume — the same pattern that already kept login sessions alive across restarts. `ENCRYPTION_KEY` and `JWT_SECRET` still take precedence, in that order, so existing deployments that set either keep deriving the same key and are unaffected.
+- **Startup now names the servers whose stored SSH key can't be decrypted.** Keys written by an affected version are unrecoverable (the ephemeral key they were encrypted with is gone), and the fallback to global SSH auth was silent apart from a per-connection log line. A single warning at boot lists the affected servers and tells you to re-enter their keys in Settings → Servers.
+
+---
+
 ## [2026.07.13-01] — 2026-07-13
 
 Fixes upgrades for non-root SSH users, which failed outright on the passwordless-sudo setup documented in the README ([#74](https://github.com/mzac/apt-ui/issues/74)), and brings the whole dependency stack up to date — React 19, Tailwind CSS 4, TypeScript 7 ([#76](https://github.com/mzac/apt-ui/pull/76)). **Tailwind 4 visibly changes the UI**: it revives ~30 utility classes that silently emitted no CSS under v3 — see *Changed* below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to apt-ui are documented here.
 
 ---
 
-## [Unreleased]
+## [2026.08.13-01] — 2026-08-13
+
+Fixes per-server SSH keys and TOTP 2FA secrets being lost on every container restart ([#77](https://github.com/mzac/apt-ui/issues/77)) — the default `docker-compose.yml`, with `ENCRYPTION_KEY` and `JWT_SECRET` both commented out, encrypted them with a key that only existed in memory.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for a full diagram and detailed breakdown
 - **SQLite** at `/data/apt-ui.db` (Docker volume). Async SQLAlchemy throughout the API; sync SQLAlchemy in the CLI only.
 - **APScheduler** (`AsyncIOScheduler`) for cron-based checks, auto-upgrades, log purge, and daily summary. Reconfigured live from the DB without restart.
 - **asyncssh**: fresh connection per command, no pool. `known_hosts=None` (trusted LAN). Auth priority: per-server encrypted key → SSH agent → global `SSH_PRIVATE_KEY`.
-- **Per-server SSH keys**: Fernet-encrypted in DB (`backend/crypto.py`). Key derived from `ENCRYPTION_KEY` env var, falling back to `JWT_SECRET`.
+- **Per-server SSH keys**: Fernet-encrypted in DB (`backend/crypto.py`). Key derived from `ENCRYPTION_KEY` env var, falling back to `JWT_SECRET`, then to a random key generated on first start and persisted in `app_config` (issue #77 — it used to be *ephemeral* in that case, so stored keys and TOTP secrets became unreadable after every restart). `seed_defaults()` in `backend/main.py` resolves it and calls `crypto.init_encryption_key()`.
 - **Auth**: HS256 JWT in httpOnly cookie `apt_ui_token` (24h). All `/api/*` except `/api/auth/login` and `/health` require `get_current_user` dependency. WebSocket auth via `get_current_user_ws`; closes with code 1008 on failure.
 - **Frontend path alias**: `@/` → `frontend/src/` (configured in both `vite.config.ts` and `tsconfig.json`).
 - **State**: Zustand stores in `frontend/src/hooks/useAuth.ts` (auth) and `frontend/src/hooks/useJobStore.ts` (background job bell).
@@ -181,8 +181,8 @@ See [TODO.md](TODO.md) for the backlog.
 |---|---|---|
 | `SSH_PRIVATE_KEY` | Yes* | PEM-encoded SSH private key (full content, not a path). Required unless `SSH_AUTH_SOCK` is set. |
 | `SSH_AUTH_SOCK` | No | SSH agent socket — alternative to `SSH_PRIVATE_KEY`. |
-| `ENCRYPTION_KEY` | No | Master key for Fernet-encrypting per-server SSH keys. Falls back to `JWT_SECRET`. |
-| `JWT_SECRET` | No | JWT signing secret. Random secret generated at startup if unset (tokens invalidate on restart). |
+| `ENCRYPTION_KEY` | No | Master key for Fernet-encrypting per-server SSH keys and TOTP secrets. Falls back to `JWT_SECRET`, then to a key auto-generated and persisted in the DB. |
+| `JWT_SECRET` | No | JWT signing secret. If unset, a random secret is generated on first start and persisted in the DB. |
 | `DATABASE_PATH` | No | Default: `/data/apt-ui.db` |
 | `TZ` | No | Timezone for scheduled jobs. Default: `America/Montreal` |
 | `ENABLE_TERMINAL` | No | Set `true` to enable the interactive SSH shell tab. Default: `false`. Only enable for trusted users. |

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ All runtime configuration (SMTP / Telegram / Slack / schedules / server list / u
 |---|---|---|
 | `SSH_PRIVATE_KEY` | — | Full PEM content of the private key. Required unless using SSH agent. |
 | `SSH_AUTH_SOCK` | — | Path to SSH agent socket inside the container (e.g. `/run/ssh-agent.sock`). Alternative to `SSH_PRIVATE_KEY` — allows passphrase-protected keys. |
-| `JWT_SECRET` | random | JWT signing secret. Set to persist sessions across restarts. |
-| `ENCRYPTION_KEY` | — | Master key used to encrypt per-server SSH keys in the DB. Falls back to `JWT_SECRET`. |
+| `JWT_SECRET` | generated | JWT signing secret. Auto-generated and stored in the DB on first start, so sessions survive restarts. |
+| `ENCRYPTION_KEY` | generated | Master key used to encrypt per-server SSH keys and TOTP secrets in the DB. Falls back to `JWT_SECRET`, then to a key auto-generated and stored in the DB on first start. Set it explicitly if you want the key managed outside the database. |
 | `DATABASE_PATH` | `/data/apt-ui.db` | SQLite file path. |
 | `TZ` | `America/Montreal` | Timezone for scheduled jobs. |
 | `LOG_LEVEL` | `INFO` | Python log level. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,7 @@ apt-ui is designed to run as a **single Docker container on a trusted private ne
 ### SSH access
 
 - The dashboard connects to managed servers over SSH using a private key supplied via the `SSH_PRIVATE_KEY` environment variable or a forwarded SSH agent socket.
-- Per-server SSH keys are stored encrypted in SQLite using Fernet (AES-128-CBC + HMAC-SHA256). The encryption key is derived from the `ENCRYPTION_KEY` env var (falls back to `JWT_SECRET`).
+- Per-server SSH keys are stored encrypted in SQLite using Fernet (AES-128-CBC + HMAC-SHA256). The encryption key is derived from the `ENCRYPTION_KEY` env var, falling back to `JWT_SECRET`, and finally to a random key generated on first start and persisted in the `app_config` table (same SQLite file, on the mounted data volume). Set `ENCRYPTION_KEY` explicitly if you want the key held outside the database.
 - Host key verification is disabled (`known_hosts=None`) — this is an intentional trade-off for fleet management on a trusted network. It is documented in the code.
 - SSH connections are opened fresh per command; there is no persistent connection pool.
 

--- a/backend/crypto.py
+++ b/backend/crypto.py
@@ -3,13 +3,17 @@ Symmetric encryption for secrets stored in the database (e.g. per-server SSH key
 
 Uses Fernet (AES-128-CBC + HMAC-SHA256) from the cryptography library.
 
-Key derivation:
+Key derivation (in order):
   1. ENCRYPTION_KEY env var (preferred — set this explicitly)
   2. JWT_SECRET env var (fallback — convenient for single-env setups)
-  3. Ephemeral random key (last resort — warns loudly; keys won't survive restarts)
+  3. Key persisted in the `app_config` table, auto-generated on first start
+     (`init_encryption_key()` is called from `seed_defaults()`). The DB lives on
+     a mounted volume, so this survives container restarts.
+  4. Ephemeral random key (last resort — warns loudly; only reached if the
+     encryption layer is used before startup initialisation).
 
-The raw env var string is SHA-256 hashed to produce a fixed-length key, so there
-are no requirements on the format or length of the env var value.
+The raw key string is SHA-256 hashed to produce a fixed-length key, so there
+are no requirements on the format or length of the value.
 """
 
 import base64
@@ -23,27 +27,39 @@ logger = logging.getLogger(__name__)
 _fernet: Fernet | None = None
 
 
-def _build_fernet() -> Fernet:
+def _fernet_from_raw(raw: str) -> Fernet:
+    key_bytes = hashlib.sha256(raw.encode()).digest()
+    return Fernet(base64.urlsafe_b64encode(key_bytes))
+
+
+def env_key() -> str:
+    """Return the encryption key from the environment, or "" if unset.
+
+    Exposed so startup code can tell whether it needs to fall back to the
+    DB-persisted key.
+    """
     from backend.config import ENCRYPTION_KEY, JWT_SECRET
 
-    raw = ENCRYPTION_KEY or JWT_SECRET
-    if raw:
-        key_bytes = hashlib.sha256(raw.encode()).digest()
-        fernet_key = base64.urlsafe_b64encode(key_bytes)
-        if not ENCRYPTION_KEY:
-            logger.info(
-                "ENCRYPTION_KEY not set — deriving encryption key from JWT_SECRET. "
-                "Set ENCRYPTION_KEY explicitly to decouple the two secrets."
-            )
-    else:
-        fernet_key = Fernet.generate_key()
-        logger.warning(
-            "Neither ENCRYPTION_KEY nor JWT_SECRET is set. "
-            "Per-server SSH keys are encrypted with an ephemeral key and will "
-            "NOT survive a container restart. Set ENCRYPTION_KEY to persist them."
-        )
+    return ENCRYPTION_KEY or JWT_SECRET
 
-    return Fernet(fernet_key)
+
+def init_encryption_key(raw: str) -> None:
+    """Called once at startup with the resolved key (env var or DB-persisted)."""
+    global _fernet
+    _fernet = _fernet_from_raw(raw)
+
+
+def _build_fernet() -> Fernet:
+    raw = env_key()
+    if raw:
+        return _fernet_from_raw(raw)
+
+    logger.warning(
+        "Encryption key requested before startup initialisation and no "
+        "ENCRYPTION_KEY / JWT_SECRET is set. Using an ephemeral key — stored "
+        "SSH keys and TOTP secrets will NOT be readable after a restart."
+    )
+    return Fernet(Fernet.generate_key())
 
 
 def _get_fernet() -> Fernet:

--- a/backend/main.py
+++ b/backend/main.py
@@ -67,13 +67,69 @@ async def seed_defaults():
                 auth_module.init_jwt_secret(new_secret)
                 logger.info("Generated and stored new JWT secret in database.")
 
+        # Encryption key for per-server SSH keys and TOTP secrets: env var if
+        # set, otherwise persist in the DB (issue #77 — an ephemeral key made
+        # stored SSH keys unusable after every container restart).
+        from backend import crypto as crypto_module
+
+        env_encryption_key = crypto_module.env_key()
+        if env_encryption_key:
+            crypto_module.init_encryption_key(env_encryption_key)
+        else:
+            result = await session.execute(
+                select(models.AppConfig).where(models.AppConfig.key == "encryption_key")
+            )
+            row = result.scalar_one_or_none()
+            if row:
+                crypto_module.init_encryption_key(row.value)
+            else:
+                new_key = secrets.token_hex(32)
+                session.add(models.AppConfig(key="encryption_key", value=new_key))
+                crypto_module.init_encryption_key(new_key)
+                logger.info(
+                    "Generated and stored a new encryption key in the database. "
+                    "Set ENCRYPTION_KEY to manage it outside the DB instead."
+                )
+
         await session.commit()
+
+
+async def warn_unreadable_ssh_keys():
+    """Log a clear warning for stored per-server SSH keys we can no longer decrypt.
+
+    Before the encryption key was persisted (issue #77) it was regenerated on
+    every restart, leaving undecryptable blobs behind. Those servers silently
+    fall back to global SSH auth, so surface them explicitly at startup.
+    """
+    from sqlalchemy import select
+    from backend.crypto import decrypt
+
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            select(models.Server).where(models.Server.ssh_private_key_enc.isnot(None))
+        )
+        broken = []
+        for server in result.scalars().all():
+            try:
+                decrypt(server.ssh_private_key_enc)
+            except Exception:
+                broken.append(server.name or server.hostname)
+
+    if broken:
+        logger.warning(
+            "⚠️  Stored SSH key could not be decrypted for %d server(s): %s. "
+            "The encryption key changed (or was ephemeral before this version). "
+            "Re-enter the SSH key for these servers in Settings → Servers; "
+            "until then they fall back to the global SSH_PRIVATE_KEY / agent.",
+            len(broken), ", ".join(sorted(broken)),
+        )
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_db()
     await seed_defaults()
+    await warn_unreadable_ssh_keys()
 
     from backend.scheduler import start_scheduler, stop_scheduler
     await start_scheduler()

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -11,7 +11,8 @@ services:
       - TZ=America/Montreal
       # Optional overrides:
       # - JWT_SECRET=change-me-to-a-random-string
-      # - ENCRYPTION_KEY=change-me-to-a-random-string  # encrypts per-server SSH keys in the DB (falls back to JWT_SECRET)
+      # - ENCRYPTION_KEY=change-me-to-a-random-string  # encrypts per-server SSH keys/TOTP secrets in the DB
+      #                                                 # (falls back to JWT_SECRET, then to a key auto-generated and stored in the DB)
       # - LOG_LEVEL=INFO
     volumes:
       - apt-ui-data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       - TZ=America/Montreal
       # Optional overrides:
       # - JWT_SECRET=change-me-to-a-random-string
-      # - ENCRYPTION_KEY=change-me-to-a-random-string  # encrypts per-server SSH keys in the DB (falls back to JWT_SECRET)
+      # - ENCRYPTION_KEY=change-me-to-a-random-string  # encrypts per-server SSH keys/TOTP secrets in the DB
+      #                                                 # (falls back to JWT_SECRET, then to a key auto-generated and stored in the DB)
       # - LOG_LEVEL=INFO
       # - ENABLE_TERMINAL=true   # Enable interactive SSH shell in the UI (disabled by default)
     volumes:


### PR DESCRIPTION
Fixes #77.

## Root cause

`backend/crypto.py` derived its Fernet key from `ENCRYPTION_KEY` → `JWT_SECRET` → `Fernet.generate_key()`. Both env vars are commented out in `docker-compose.yml`, so the default deployment landed on the third branch — **a fresh random key generated in memory on every process start**.

Keys were encrypted correctly, but the next restart derived a different key, so every stored blob became undecryptable. `_connect_options` in `backend/ssh_manager.py` then silently fell back to the global `SSH_PRIVATE_KEY` / agent auth, which is why "all configured servers are unable to connect". TOTP 2FA secrets (`users.totp_secret_enc`) were broken by the same bug.

The JWT secret already had the right fix — `seed_defaults()` persists it in the `app_config` table, which lives on the mounted data volume. The encryption key just never got the same treatment.

## The fix

- `backend/crypto.py`: new `env_key()` and `init_encryption_key()`. The ephemeral branch is now only reachable if the encryption layer is used before startup initialisation, and warns loudly.
- `backend/main.py`: `seed_defaults()` resolves the key once — `ENCRYPTION_KEY` → `JWT_SECRET` → `app_config.encryption_key`, generating and storing a random one on first start.
- `ENCRYPTION_KEY` and `JWT_SECRET` keep precedence in that order, so **existing deployments that set either derive the same key as before and are unaffected**.
- Blobs written by an affected version are unrecoverable (the ephemeral key that encrypted them is gone). `warn_unreadable_ssh_keys()` logs a single startup warning naming the affected servers and pointing at Settings → Servers to re-enter their keys, instead of leaving the fallback silent.

No schema migration needed — `app_config` is an existing key-value table and this is a new row, not a new column.

## Testing

Manual, against a temp SQLite DB with `seed_defaults()` re-run to simulate container restarts:

- No env vars: encrypt in run 1 → decrypt in run 2 returns the original plaintext (previously raised `InvalidToken`).
- `ENCRYPTION_KEY` set: no `encryption_key` row is written to `app_config`, and decryption across restarts still works via the env var.
- Corrupt/foreign ciphertext: the startup warning fires and names only the affected server.

`make ci` passes.

## Docs

CHANGELOG (Unreleased), README env table, SECURITY.md, CLAUDE.md, ARCHITECTURE.md, and both compose files updated to describe the new fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)